### PR TITLE
Add configuration file for black to set default line length to 79

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+
+[tool.black]
+line-length = 79
+


### PR DESCRIPTION
Since starting to use ``black`` for code formatting (e.g., #10  ), I have had to remember to specify the default line length every time I use the program. This configuration file automatically specifies that choice for this project. 