### PR TITLE
Fix mbuild/foyer channel priority in install instructions

### DIFF
--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -21,7 +21,7 @@ mbuild, foyer, and numpy can be installed via conda:
 
 .. code-block:: bash
 
-    conda install -c omnia -c mosdef -c conda-forge --file mosdef_cassandra/requirements.txt
+    conda install -c conda-forge -c mosdef -c omnia --file mosdef_cassandra/requirements.txt
     conda install -c conda-forge openbabel
 
 The second line installs openbabel. It is not a strict requirement,


### PR DESCRIPTION
Install instructions from `mbuild` and `foyer` had the wrong channel priority. The channel priority decreases from left to right: https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/channels.html#specifying-channels-when-installing-packages.