### PR TITLE
Prevent ensemble property of moves object from being edited

### DIFF
--- a/mosdef_cassandra/core/moves.py
+++ b/mosdef_cassandra/core/moves.py
@@ -274,6 +274,10 @@ class Moves(object):
 
     @ensemble.setter
     def ensemble(self, ensemble):
+        if hasattr(self, "_ensemble"):
+            raise AttributeError(
+                "Ensemble cannot be changed. Please create a new Moves object instead."
+            )
         valid_ensembles = ["nvt", "npt", "gcmc", "gemc", "gemc_npt"]
         if ensemble not in valid_ensembles:
             raise ValueError(

--- a/mosdef_cassandra/tests/test_moves.py
+++ b/mosdef_cassandra/tests/test_moves.py
@@ -554,3 +554,10 @@ class TestMoves(BaseTest):
             moves.add_restricted_insertions(
                 [methane_oplsaa], [["cylinder"]], [[3]]
             )
+
+    def test_change_ensemble(self, methane_oplsaa):
+        moves = mc.Moves("gcmc", [methane_oplsaa])
+        with pytest.raises(
+            AttributeError, match=r"Ensemble cannot be changed"
+        ):
+            moves.ensemble = "nvt"


### PR DESCRIPTION
Prevents the `ensemble` attribute of the moves object from being edited after the moves object is created. The moves object contains default selections that are made based upon the ensemble that is selected when the object is initially created. Instead of allowing the user to edit the ensemble after the moves object has been created, this PR instead requires that the user create a new moves object if they wish to change ensembles. 

Closes #50 , related to #3 

 