### PR TITLE
Add overwrite=True flag to xyz input writer

### DIFF
--- a/mosdef_cassandra/writers/writers.py
+++ b/mosdef_cassandra/writers/writers.py
@@ -60,7 +60,7 @@ def write_configs(system):
         # This only occurs if box is an mbuild.Compound
         if isinstance(box, mbuild.Compound):
             xyz_name = "box{}.in.xyz".format(box_count + 1)
-            box.save(xyz_name)
+            box.save(xyz_name, overwrite=True)
 
 
 def write_input(system, moves, run_type, run_length, temperature, **kwargs):


### PR DESCRIPTION
Concluded that it was OK to overwrite the input xyz file for two reasons:

(1) We already overwrite the other files generated by mosdef_cassandra (.inp, .mcf). 
(2) The filename is unique enough that it is unlikely to be something someone would already be using: `box1.in.xyz`

It may be prudent to add some documentation that warns that `mosdef_cassandra` writes (and might overwrite) files in the working directory. 

Closes #38. 