### PR TITLE
Update moves attributes

### DIFF
--- a/mosdef_cassandra/core/moves.py
+++ b/mosdef_cassandra/core/moves.py
@@ -124,9 +124,13 @@ class Moves(object):
 
         # Remaining options are per-species
         self.max_dihedral = [0.0] * self._n_species
-        self.sp_insertable = [True] * self._n_species
-        self.sp_prob_swap = [1.0] * self._n_species
         self.sp_prob_regrow = [1.0] * self._n_species
+        if self.ensemble in ["gcmc", "gemc", "gemc_npt"]:
+            self.sp_insertable = [True] * self._n_species
+            self.sp_prob_swap = [1.0] * self._n_species
+        else:
+            self.sp_insertable = [False] * self._n_species
+            self.sp_prob_swap = [0.0] * self._n_species
 
         # Here we handle species-wise exceptions
         for ispec, species in enumerate(species_topologies):

--- a/mosdef_cassandra/core/moves.py
+++ b/mosdef_cassandra/core/moves.py
@@ -76,10 +76,10 @@ class Moves(object):
             self.prob_insert = 0.0
             self.prob_swap = 0.0
         elif self.ensemble == "npt":
-            self.prob_translate = 0.34
-            self.prob_rotate = 0.34
-            self.prob_regrow = 0.30
-            self.prob_volume = 0.02
+            self.prob_translate = 0.33
+            self.prob_rotate = 0.33
+            self.prob_regrow = 0.335
+            self.prob_volume = 0.005
             self.prob_insert = 0.0
             self.prob_swap = 0.0
         # GCMC sums to 0.9 b/c symmetric prob_delete
@@ -91,17 +91,17 @@ class Moves(object):
             self.prob_insert = 0.1
             self.prob_swap = 0.0
         elif self.ensemble == "gemc":
-            self.prob_translate = 0.29
-            self.prob_rotate = 0.29
-            self.prob_regrow = 0.30
-            self.prob_volume = 0.02
+            self.prob_translate = 0.30
+            self.prob_rotate = 0.30
+            self.prob_regrow = 0.295
+            self.prob_volume = 0.005
             self.prob_insert = 0.0
             self.prob_swap = 0.1
         elif self.ensemble == "gemc_npt":
-            self.prob_translate = 0.29
-            self.prob_rotate = 0.29
-            self.prob_regrow = 0.30
-            self.prob_volume = 0.02
+            self.prob_translate = 0.30
+            self.prob_rotate = 0.30
+            self.prob_regrow = 0.295
+            self.prob_volume = 0.005
             self.prob_insert = 0.0
             self.prob_swap = 0.1
         else:

--- a/mosdef_cassandra/core/moves.py
+++ b/mosdef_cassandra/core/moves.py
@@ -69,9 +69,9 @@ class Moves(object):
         self.prob_dihedral = 0.0
 
         if self.ensemble == "nvt":
-            self.prob_translate = 0.35
-            self.prob_rotate = 0.35
-            self.prob_regrow = 0.30
+            self.prob_translate = 0.33
+            self.prob_rotate = 0.33
+            self.prob_regrow = 0.34
             self.prob_volume = 0.0
             self.prob_insert = 0.0
             self.prob_swap = 0.0

--- a/mosdef_cassandra/core/moves.py
+++ b/mosdef_cassandra/core/moves.py
@@ -127,9 +127,11 @@ class Moves(object):
         self.prob_regrow_species = [1.0] * self._n_species
         if self.ensemble in ["gcmc", "gemc", "gemc_npt"]:
             self.insertable = [True] * self._n_species
-            self.prob_swap_species = [1.0] * self._n_species
         else:
             self.insertable = [False] * self._n_species
+        if self.ensemble in ["gemc", "gemc_npt"]:
+            self.prob_swap_species = [1.0] * self._n_species
+        else:
             self.prob_swap_species = [0.0] * self._n_species
 
         # Here we handle species-wise exceptions

--- a/mosdef_cassandra/tests/test_moves.py
+++ b/mosdef_cassandra/tests/test_moves.py
@@ -26,9 +26,9 @@ class TestMoves(BaseTest):
     def test_ensemble_nvt(self, methane_oplsaa):
         moves = mc.Moves("nvt", [methane_oplsaa])
         assert moves.ensemble == "nvt"
-        assert moves.prob_translate == 0.35
-        assert moves.prob_rotate == 0.35
-        assert moves.prob_regrow == 0.30
+        assert moves.prob_translate == 0.33
+        assert moves.prob_rotate == 0.33
+        assert moves.prob_regrow == 0.34
         assert moves.prob_volume == 0.0
         assert moves.prob_angle == 0.0
         assert moves.prob_dihedral == 0.0

--- a/mosdef_cassandra/tests/test_moves.py
+++ b/mosdef_cassandra/tests/test_moves.py
@@ -56,10 +56,10 @@ class TestMoves(BaseTest):
     def test_ensemble_npt(self, methane_oplsaa):
         moves = mc.Moves("npt", [methane_oplsaa])
         assert moves.ensemble == "npt"
-        assert moves.prob_translate == 0.34
-        assert moves.prob_rotate == 0.34
-        assert moves.prob_regrow == 0.30
-        assert moves.prob_volume == 0.02
+        assert moves.prob_translate == 0.33
+        assert moves.prob_rotate == 0.33
+        assert moves.prob_regrow == 0.335
+        assert moves.prob_volume == 0.005
         assert moves.prob_angle == 0.0
         assert moves.prob_dihedral == 0.0
         assert moves.prob_insert == 0.0
@@ -132,10 +132,10 @@ class TestMoves(BaseTest):
     def test_ensemble_gemc(self, methane_oplsaa):
         moves = mc.Moves("gemc", [methane_oplsaa])
         assert moves.ensemble == "gemc"
-        assert moves.prob_translate == 0.29
-        assert moves.prob_rotate == 0.29
-        assert moves.prob_regrow == 0.30
-        assert moves.prob_volume == 0.02
+        assert moves.prob_translate == 0.30
+        assert moves.prob_rotate == 0.30
+        assert moves.prob_regrow == 0.295
+        assert moves.prob_volume == 0.005
         assert moves.prob_angle == 0.0
         assert moves.prob_dihedral == 0.0
         assert moves.prob_insert == 0.0
@@ -183,10 +183,10 @@ class TestMoves(BaseTest):
     def test_ensemble_gemcnpt(self, methane_oplsaa):
         moves = mc.Moves("gemc_npt", [methane_oplsaa])
         assert moves.ensemble == "gemc_npt"
-        assert moves.prob_translate == 0.29
-        assert moves.prob_rotate == 0.29
-        assert moves.prob_regrow == 0.30
-        assert moves.prob_volume == 0.02
+        assert moves.prob_translate == 0.30
+        assert moves.prob_rotate == 0.30
+        assert moves.prob_regrow == 0.295
+        assert moves.prob_volume == 0.005
         assert moves.prob_angle == 0.0
         assert moves.prob_dihedral == 0.0
         assert moves.prob_insert == 0.0
@@ -260,8 +260,8 @@ class TestMoves(BaseTest):
         assert moves.ensemble == "gemc"
         assert moves.prob_rotate == 0.0
         assert moves.prob_regrow == 0.0
-        assert moves.prob_translate == pytest.approx(0.88)
-        assert moves.prob_volume == 0.02
+        assert moves.prob_translate == pytest.approx(0.895)
+        assert moves.prob_volume == 0.005
         assert moves.prob_angle == 0.0
         assert moves.prob_dihedral == 0.0
         assert moves.prob_insert == 0.0

--- a/mosdef_cassandra/tests/test_moves.py
+++ b/mosdef_cassandra/tests/test_moves.py
@@ -49,10 +49,9 @@ class TestMoves(BaseTest):
         assert len(moves.sp_insertable) == 1
         assert len(moves.sp_prob_swap) == 1
         assert len(moves.sp_prob_regrow) == 1
-
-        # Should be insertable and regrow-able
-        assert moves.sp_insertable[0] == True
+        # Should be regrow-able but not insertable
         assert moves.sp_prob_regrow[0] == 1.0
+        assert moves.sp_insertable[0] == False
 
     def test_ensemble_npt(self, methane_oplsaa):
         moves = mc.Moves("npt", [methane_oplsaa])
@@ -80,10 +79,9 @@ class TestMoves(BaseTest):
         assert len(moves.sp_insertable) == 1
         assert len(moves.sp_prob_swap) == 1
         assert len(moves.sp_prob_regrow) == 1
-
-        # Should be insertable and regrow-able
-        assert moves.sp_insertable[0] == True
+        # Should be regrow-able but not insertable
         assert moves.sp_prob_regrow[0] == 1.0
+        assert moves.sp_insertable[0] == False
 
     def test_ensemble_gcmc(self, methane_oplsaa):
         moves = mc.Moves("gcmc", [methane_oplsaa])
@@ -111,7 +109,6 @@ class TestMoves(BaseTest):
         assert len(moves.sp_insertable) == 1
         assert len(moves.sp_prob_swap) == 1
         assert len(moves.sp_prob_regrow) == 1
-
         # Should be insertable and regrow-able
         assert moves.sp_insertable[0] == True
         assert moves.sp_prob_regrow[0] == 1.0
@@ -161,7 +158,6 @@ class TestMoves(BaseTest):
         assert len(moves.sp_insertable) == 1
         assert len(moves.sp_prob_swap) == 1
         assert len(moves.sp_prob_regrow) == 1
-
         # Should be insertable and regrow-able
         assert moves.sp_insertable[0] == True
         assert moves.sp_prob_regrow[0] == 1.0
@@ -214,7 +210,6 @@ class TestMoves(BaseTest):
         assert len(moves.sp_insertable) == 1
         assert len(moves.sp_prob_swap) == 1
         assert len(moves.sp_prob_regrow) == 1
-
         # Should be insertable and regrow-able
         assert moves.sp_insertable[0] == True
         assert moves.sp_prob_regrow[0] == 1.0
@@ -255,9 +250,8 @@ class TestMoves(BaseTest):
         assert len(moves.sp_insertable) == 1
         assert len(moves.sp_prob_swap) == 1
         assert len(moves.sp_prob_regrow) == 1
-
-        # Should be insertable and NOT regrow-able
-        assert moves.sp_insertable[0] == True
+        # Should NOT be insertable or regrow-able
+        assert moves.sp_insertable[0] == False
         assert moves.sp_prob_regrow[0] == 0.0
 
     def test_single_site_gemc(self, methane_trappe):
@@ -290,7 +284,6 @@ class TestMoves(BaseTest):
         assert len(moves.sp_insertable) == 1
         assert len(moves.sp_prob_swap) == 1
         assert len(moves.sp_prob_regrow) == 1
-
         # Should be insertable and NOT regrow-able
         assert moves.sp_insertable[0] == True
         assert moves.sp_prob_regrow[0] == 0.0
@@ -322,7 +315,6 @@ class TestMoves(BaseTest):
         assert len(moves.sp_insertable) == 2
         assert len(moves.sp_prob_swap) == 2
         assert len(moves.sp_prob_regrow) == 2
-
         # Lattice should not be insertable or regrow-able
         assert moves.sp_insertable[0] == False
         assert moves.sp_prob_regrow[0] == 0.0

--- a/mosdef_cassandra/tests/test_moves.py
+++ b/mosdef_cassandra/tests/test_moves.py
@@ -46,12 +46,12 @@ class TestMoves(BaseTest):
         assert len(moves.max_translate[0]) == 1
         assert len(moves.max_rotate[0]) == 1
         # Per species attributes
-        assert len(moves.sp_insertable) == 1
-        assert len(moves.sp_prob_swap) == 1
-        assert len(moves.sp_prob_regrow) == 1
+        assert len(moves.insertable) == 1
+        assert len(moves.prob_swap_species) == 1
+        assert len(moves.prob_regrow_species) == 1
         # Should be regrow-able but not insertable
-        assert moves.sp_prob_regrow[0] == 1.0
-        assert moves.sp_insertable[0] == False
+        assert moves.prob_regrow_species[0] == 1.0
+        assert moves.insertable[0] == False
 
     def test_ensemble_npt(self, methane_oplsaa):
         moves = mc.Moves("npt", [methane_oplsaa])
@@ -76,12 +76,12 @@ class TestMoves(BaseTest):
         assert len(moves.max_translate[0]) == 1
         assert len(moves.max_rotate[0]) == 1
         # Per species attributes
-        assert len(moves.sp_insertable) == 1
-        assert len(moves.sp_prob_swap) == 1
-        assert len(moves.sp_prob_regrow) == 1
+        assert len(moves.insertable) == 1
+        assert len(moves.prob_swap_species) == 1
+        assert len(moves.prob_regrow_species) == 1
         # Should be regrow-able but not insertable
-        assert moves.sp_prob_regrow[0] == 1.0
-        assert moves.sp_insertable[0] == False
+        assert moves.prob_regrow_species[0] == 1.0
+        assert moves.insertable[0] == False
 
     def test_ensemble_gcmc(self, methane_oplsaa):
         moves = mc.Moves("gcmc", [methane_oplsaa])
@@ -106,12 +106,12 @@ class TestMoves(BaseTest):
         assert len(moves.max_translate[0]) == 1
         assert len(moves.max_rotate[0]) == 1
         # Per species attributes
-        assert len(moves.sp_insertable) == 1
-        assert len(moves.sp_prob_swap) == 1
-        assert len(moves.sp_prob_regrow) == 1
+        assert len(moves.insertable) == 1
+        assert len(moves.prob_swap_species) == 1
+        assert len(moves.prob_regrow_species) == 1
         # Should be insertable and regrow-able
-        assert moves.sp_insertable[0] == True
-        assert moves.sp_prob_regrow[0] == 1.0
+        assert moves.insertable[0] == True
+        assert moves.prob_regrow_species[0] == 1.0
 
     @pytest.mark.parametrize(
         "typ,value",
@@ -155,12 +155,12 @@ class TestMoves(BaseTest):
         assert len(moves.max_translate[1]) == 1
         assert len(moves.max_rotate[1]) == 1
         # Per species attributes
-        assert len(moves.sp_insertable) == 1
-        assert len(moves.sp_prob_swap) == 1
-        assert len(moves.sp_prob_regrow) == 1
+        assert len(moves.insertable) == 1
+        assert len(moves.prob_swap_species) == 1
+        assert len(moves.prob_regrow_species) == 1
         # Should be insertable and regrow-able
-        assert moves.sp_insertable[0] == True
-        assert moves.sp_prob_regrow[0] == 1.0
+        assert moves.insertable[0] == True
+        assert moves.prob_regrow_species[0] == 1.0
 
     @pytest.mark.parametrize(
         "typ,value",
@@ -207,12 +207,12 @@ class TestMoves(BaseTest):
         assert len(moves.max_translate[1]) == 1
         assert len(moves.max_rotate[1]) == 1
         # Per species attributes
-        assert len(moves.sp_insertable) == 1
-        assert len(moves.sp_prob_swap) == 1
-        assert len(moves.sp_prob_regrow) == 1
+        assert len(moves.insertable) == 1
+        assert len(moves.prob_swap_species) == 1
+        assert len(moves.prob_regrow_species) == 1
         # Should be insertable and regrow-able
-        assert moves.sp_insertable[0] == True
-        assert moves.sp_prob_regrow[0] == 1.0
+        assert moves.insertable[0] == True
+        assert moves.prob_regrow_species[0] == 1.0
 
     def test_restricted_gemc_npt(self, methane_oplsaa):
         moves = mc.Moves("gemc_npt", [methane_oplsaa])
@@ -247,12 +247,12 @@ class TestMoves(BaseTest):
         assert len(moves.max_translate[0]) == 1
         assert len(moves.max_rotate[0]) == 1
         # Per species attributes
-        assert len(moves.sp_insertable) == 1
-        assert len(moves.sp_prob_swap) == 1
-        assert len(moves.sp_prob_regrow) == 1
+        assert len(moves.insertable) == 1
+        assert len(moves.prob_swap_species) == 1
+        assert len(moves.prob_regrow_species) == 1
         # Should NOT be insertable or regrow-able
-        assert moves.sp_insertable[0] == False
-        assert moves.sp_prob_regrow[0] == 0.0
+        assert moves.insertable[0] == False
+        assert moves.prob_regrow_species[0] == 0.0
 
     def test_single_site_gemc(self, methane_trappe):
 
@@ -281,12 +281,12 @@ class TestMoves(BaseTest):
         assert len(moves.max_rotate[0]) == 1
         assert len(moves.max_rotate[1]) == 1
         # Per species attributes
-        assert len(moves.sp_insertable) == 1
-        assert len(moves.sp_prob_swap) == 1
-        assert len(moves.sp_prob_regrow) == 1
+        assert len(moves.insertable) == 1
+        assert len(moves.prob_swap_species) == 1
+        assert len(moves.prob_regrow_species) == 1
         # Should be insertable and NOT regrow-able
-        assert moves.sp_insertable[0] == True
-        assert moves.sp_prob_regrow[0] == 0.0
+        assert moves.insertable[0] == True
+        assert moves.prob_regrow_species[0] == 0.0
 
     def test_gcmc_lattice(self, fixed_lattice_trappe, methane_trappe):
 
@@ -312,15 +312,15 @@ class TestMoves(BaseTest):
         assert len(moves.max_translate[0]) == 2
         assert len(moves.max_rotate[0]) == 2
         # Per species attributes
-        assert len(moves.sp_insertable) == 2
-        assert len(moves.sp_prob_swap) == 2
-        assert len(moves.sp_prob_regrow) == 2
+        assert len(moves.insertable) == 2
+        assert len(moves.prob_swap_species) == 2
+        assert len(moves.prob_regrow_species) == 2
         # Lattice should not be insertable or regrow-able
-        assert moves.sp_insertable[0] == False
-        assert moves.sp_prob_regrow[0] == 0.0
+        assert moves.insertable[0] == False
+        assert moves.prob_regrow_species[0] == 0.0
         # Methane should be insertable and not regrow-able
-        assert moves.sp_insertable[1] == True
-        assert moves.sp_prob_regrow[1] == 0.0
+        assert moves.insertable[1] == True
+        assert moves.prob_regrow_species[1] == 0.0
 
     def test_prob_setters(self, methane_oplsaa):
         moves = mc.Moves("nvt", [methane_oplsaa])
@@ -469,35 +469,35 @@ class TestMoves(BaseTest):
 
         moves = mc.Moves("gemc", [methane_oplsaa])
         with pytest.raises(ValueError, match=r"must be a list"):
-            moves.sp_insertable = 1.0
+            moves.insertable = 1.0
         with pytest.raises(ValueError, match=r"must be a list"):
-            moves.sp_insertable = [1.0, 1.0, 1.0]
+            moves.insertable = [1.0, 1.0, 1.0]
         with pytest.raises(TypeError, match=r"as a boolean type"):
-            moves.sp_insertable = [2.0]
-        moves.sp_insertable = [True]
-        assert moves.sp_insertable[0] == True
+            moves.insertable = [2.0]
+        moves.insertable = [True]
+        assert moves.insertable[0] == True
 
         with pytest.raises(ValueError, match=r"must be a list"):
-            moves.sp_prob_swap = 1.0
+            moves.prob_swap_species = 1.0
         with pytest.raises(ValueError, match=r"must be a list"):
-            moves.sp_prob_swap = [1.0, 1.0, 1.0]
+            moves.prob_swap_species = [1.0, 1.0, 1.0]
         with pytest.raises(TypeError, match=r"of type float"):
-            moves.sp_prob_swap = [True]
+            moves.prob_swap_species = [True]
         with pytest.raises(ValueError, match=r"cannot be less than zero"):
-            moves.sp_prob_swap = [-1.0]
-        moves.sp_prob_swap = [1.0]
-        assert moves.sp_prob_swap[0] == 1.0
+            moves.prob_swap_species = [-1.0]
+        moves.prob_swap_species = [1.0]
+        assert moves.prob_swap_species[0] == 1.0
 
         with pytest.raises(ValueError, match=r"must be a list"):
-            moves.sp_prob_regrow = 1.0
+            moves.prob_regrow_species = 1.0
         with pytest.raises(ValueError, match=r"must be a list"):
-            moves.sp_prob_regrow = [1.0, 1.0, 1.0]
+            moves.prob_regrow_species = [1.0, 1.0, 1.0]
         with pytest.raises(TypeError, match=r"of type float"):
-            moves.sp_prob_regrow = [True]
+            moves.prob_regrow_species = [True]
         with pytest.raises(ValueError, match=r"cannot be less than zero"):
-            moves.sp_prob_regrow = [-1.0]
-        moves.sp_prob_regrow = [1.0]
-        assert moves.sp_prob_regrow[0] == 1.0
+            moves.prob_regrow_species = [-1.0]
+        moves.prob_regrow_species = [1.0]
+        assert moves.prob_regrow_species[0] == 1.0
 
     def test_print_moves(self, methane_oplsaa):
         """Simple test to make sure moves object is printed"""

--- a/mosdef_cassandra/tests/test_writers.py
+++ b/mosdef_cassandra/tests/test_writers.py
@@ -971,11 +971,11 @@ class TestInpFunctions(BaseTest):
 
         assert "# Move_Probability_Info" in inp_data
         assert "# Done_Probability_Info" in inp_data
-        assert "# Prob_Translation\n0.35\n2.0 \n" in inp_data
-        assert "# Prob_Rotation\n0.35\n30.0 \n" in inp_data
+        assert "# Prob_Translation\n0.33\n2.0 \n" in inp_data
+        assert "# Prob_Rotation\n0.33\n30.0 \n" in inp_data
         assert "# Prob_Angle" not in inp_data
         assert "# Prob_Dihedral" not in inp_data
-        assert "# Prob_Regrowth\n0.3\n1.0 \n" in inp_data
+        assert "# Prob_Regrowth\n0.34\n1.0 \n" in inp_data
         assert "# Prob_Volume" not in inp_data
         assert "# Prob_Insertion" not in inp_data
         assert "# Prob_Deletion" not in inp_data
@@ -985,6 +985,7 @@ class TestInpFunctions(BaseTest):
         moves.prob_angle = 0.1
         moves.prob_translate = 0.3
         moves.prob_rotate = 0.3
+        moves.prob_regrow = 0.3
         moves.max_translate[0][0] = 10.0
         moves.max_rotate[0][0] = 10.0
 
@@ -1022,11 +1023,11 @@ class TestInpFunctions(BaseTest):
 
         assert "# Move_Probability_Info" in inp_data
         assert "# Done_Probability_Info" in inp_data
-        assert "# Prob_Translation\n0.35\n2.0 2.0 \n" in inp_data
-        assert "# Prob_Rotation\n0.35\n30.0 30.0 \n" in inp_data
+        assert "# Prob_Translation\n0.33\n2.0 2.0 \n" in inp_data
+        assert "# Prob_Rotation\n0.33\n30.0 30.0 \n" in inp_data
         assert "# Prob_Angle" not in inp_data
         assert "# Prob_Dihedral" not in inp_data
-        assert "# Prob_Regrowth\n0.3\n0.5 0.5 \n" in inp_data
+        assert "# Prob_Regrowth\n0.34\n0.5 0.5 \n" in inp_data
         assert "# Prob_Volume" not in inp_data
         assert "# Prob_Insertion" not in inp_data
         assert "# Prob_Deletion" not in inp_data
@@ -1036,6 +1037,7 @@ class TestInpFunctions(BaseTest):
         moves.prob_angle = 0.1
         moves.prob_translate = 0.3
         moves.prob_rotate = 0.3
+        moves.prob_regrow = 0.26
         moves.max_translate[0][0] = 10.0
         moves.max_rotate[0][0] = 10.0
 
@@ -1053,7 +1055,7 @@ class TestInpFunctions(BaseTest):
         assert "# Prob_Rotation\n0.3\n10.0 30.0 \n" in inp_data
         assert "# Prob_Angle\n0.1\n" in inp_data
         assert "# Prob_Dihedral" not in inp_data
-        assert "# Prob_Regrowth\n0.3\n0.5 0.5 \n" in inp_data
+        assert "# Prob_Regrowth\n0.26\n0.5 0.5 \n" in inp_data
         assert "# Prob_Volume" not in inp_data
         assert "# Prob_Insertion" not in inp_data
         assert "# Prob_Deletion" not in inp_data

--- a/mosdef_cassandra/tests/test_writers.py
+++ b/mosdef_cassandra/tests/test_writers.py
@@ -1073,12 +1073,12 @@ class TestInpFunctions(BaseTest):
 
         assert "# Move_Probability_Info" in inp_data
         assert "# Done_Probability_Info" in inp_data
-        assert "# Prob_Translation\n0.29\n2.0 \n2.0 \n" in inp_data
-        assert "# Prob_Rotation\n0.29\n30.0 \n30.0 \n" in inp_data
+        assert "# Prob_Translation\n0.3\n2.0 \n2.0 \n" in inp_data
+        assert "# Prob_Rotation\n0.3\n30.0 \n30.0 \n" in inp_data
         assert "# Prob_Angle" not in inp_data
         assert "# Prob_Dihedral" not in inp_data
-        assert "# Prob_Regrowth\n0.3\n1.0 \n" in inp_data
-        assert "# Prob_Volume\n0.02\n500.0\n" in inp_data
+        assert "# Prob_Regrowth\n0.295\n1.0 \n" in inp_data
+        assert "# Prob_Volume\n0.005\n500.0\n" in inp_data
         assert "# Prob_Insertion" not in inp_data
         assert "# Prob_Deletion" not in inp_data
         assert (
@@ -1100,12 +1100,12 @@ class TestInpFunctions(BaseTest):
         )
         assert "# Move_Probability_Info" in inp_data
         assert "# Done_Probability_Info" in inp_data
-        assert "# Prob_Translation\n0.29\n2.0 2.0 \n2.0 2.0 \n" in inp_data
-        assert "# Prob_Rotation\n0.29\n30.0 30.0 \n30.0 30.0 \n" in inp_data
+        assert "# Prob_Translation\n0.3\n2.0 2.0 \n2.0 2.0 \n" in inp_data
+        assert "# Prob_Rotation\n0.3\n30.0 30.0 \n30.0 30.0 \n" in inp_data
         assert "# Prob_Angle" not in inp_data
         assert "# Prob_Dihedral" not in inp_data
-        assert "# Prob_Regrowth\n0.3\n0.5 0.5 \n" in inp_data
-        assert "# Prob_Volume\n0.02\n500.0\n5000.0\n" in inp_data
+        assert "# Prob_Regrowth\n0.295\n0.5 0.5 \n" in inp_data
+        assert "# Prob_Volume\n0.005\n500.0\n5000.0\n" in inp_data
         assert "# Prob_Insertion" not in inp_data
         assert "# Prob_Deletion" not in inp_data
         assert (

--- a/mosdef_cassandra/writers/inp_functions.py
+++ b/mosdef_cassandra/writers/inp_functions.py
@@ -225,7 +225,7 @@ def generate_input(system, moves, run_type, run_length, temperature, **kwargs):
                 max_mols += system.mols_in_boxes[ibox][isp]
                 max_mols += system.mols_to_add[ibox][isp]
             # TODO: Document/improve this
-            if moves.ensemble == "gcmc" and moves.sp_insertable[isp]:
+            if moves.ensemble == "gcmc" and moves.insertable[isp]:
                 max_mols += 500
 
             max_molecules_dict["species%d.mcf" % (isp + 1)] = max_mols
@@ -284,7 +284,7 @@ def generate_input(system, moves, run_type, run_length, temperature, **kwargs):
             )
 
         for isp, chempot in enumerate(chemical_potentials):
-            if moves.sp_insertable[isp] == False and chempot != "none":
+            if moves.insertable[isp] == False and chempot != "none":
                 raise ValueError(
                     "The chemical potential of non-insertable "
                     'species should be "none"'
@@ -307,16 +307,19 @@ def generate_input(system, moves, run_type, run_length, temperature, **kwargs):
     if moves.prob_dihedral > 0.0:
         move_prob_dict["dihedral"] = [moves.prob_dihedral, moves.max_dihedrals]
     if moves.prob_regrow > 0.0:
-        move_prob_dict["regrow"] = [moves.prob_regrow, moves.sp_prob_regrow]
+        move_prob_dict["regrow"] = [
+            moves.prob_regrow,
+            moves.prob_regrow_species,
+        ]
     if moves.prob_volume > 0.0:
         move_prob_dict["volume"] = [moves.prob_volume, moves.max_volume]
     if moves.prob_insert > 0.0:
-        move_prob_dict["insert"] = [moves.prob_insert, moves.sp_insertable]
+        move_prob_dict["insert"] = [moves.prob_insert, moves.insertable]
     if moves.prob_swap > 0.0:
         move_prob_dict["swap"] = [
             moves.prob_swap,
-            moves.sp_insertable,
-            moves.sp_prob_swap,
+            moves.insertable,
+            moves.prob_swap_species,
             moves.prob_swap_from_box,
         ]
     if moves._restricted_type and moves._restricted_value:


### PR DESCRIPTION
Changes to the moves attributes.

Rename some per-species attributes:

* `sp_insertable` -> `insertable`
* `sp_prob_regrow` -> `prob_regrow_species`
* `sp_prob_swap` -> `prob_swap_species`

Change some default values:

* Sets `insertable` to `False` unless an open ensemble
* Sets `prob_swap_species` to 0.0 unless GEMC or GEMC-NpT
* Sets default volume swap probability to 0.005 from 0.02
