### PR TITLE
Combine CBMC options into Moves

### DIFF
--- a/mosdef_cassandra/core/moves.py
+++ b/mosdef_cassandra/core/moves.py
@@ -591,35 +591,37 @@ class Moves(object):
 
     @max_volume.setter
     def max_volume(self, max_volume):
-        if not isinstance(max_volume, list):
-            raise ValueError(
-                "max_volume must be a list with " "length (number of boxes)"
+        if type(max_volume) not in (list, float, int):
+            raise TypeError(
+                "max_volume must be a float, or, optionally, "
+                "a list with length (number of boxes)"
             )
-        if self.ensemble != "gemc":
-            if len(max_volume) != self._n_boxes:
-                raise ValueError(
-                    "max_volume must be a list with "
-                    "length (number of boxes)"
-                )
+        if type(max_volume) == list:
+            if self.ensemble == "gemc_npt":
+                if len(max_volume) != self._n_boxes:
+                    raise TypeError(
+                        "max_volume must be a float or a list with length "
+                        "(number of boxes) for gemc_npt"
+                    )
+            else:
+                if len(max_volume) != 1:
+                    raise TypeError(
+                        "max_volume must be a float or a list with length "
+                        "1 for all ensembles except gemc_npt"
+                    )
         else:
-            if len(max_volume) != 1:
-                raise ValueError(
-                    "max_volume must be a list of " "length (1) for gemc"
-                )
+            if self.ensemble == "gemc_npt":
+                max_volume = [max_volume] * self._n_boxes
+            else:
+                max_volume = [max_volume]
+
         for max_vol in max_volume:
             if type(max_vol) not in (float, int):
-                raise TypeError(
-                    "Maximum volume change for a box " "must be of type float"
-                )
-            else:
-                max_vol = float(max_vol)
+                raise TypeError("max_volume values must be of type float")
             if max_vol < 0.0:
-                raise ValueError(
-                    "Maximum volume change for a box "
-                    "cannot be less than zero"
-                )
+                raise ValueError("max_volume cannot be less than zero.")
 
-        self._max_volume = max_volume
+        self._max_volume = [float(max_vol) for max_vol in max_volume]
 
     @property
     def insertable(self):
@@ -739,7 +741,7 @@ class Moves(object):
         if type(cbmc_rcut) not in (list, float, int):
             raise TypeError(
                 "cbmc_rcut must be a float, or, optionally, "
-                "systems, a list with length (number of boxes)"
+                "a list with length (number of boxes)"
             )
         if type(cbmc_rcut) == list:
             if len(cbmc_rcut) != self._n_boxes:
@@ -753,12 +755,10 @@ class Moves(object):
         for rcut in cbmc_rcut:
             if type(rcut) not in (float, int):
                 raise TypeError("cbmc_rcut values must be of type float")
-            else:
-                rcut = float(rcut)
             if rcut < 0.0:
                 raise ValueError("cbmc_rcut cannot be less than zero.")
 
-        self._cbmc_rcut = cbmc_rcut
+        self._cbmc_rcut = [float(rcut) for rcut in cbmc_rcut]
 
     def print(self):
         """Print the current contents of Moves"""

--- a/mosdef_cassandra/tests/test_moves.py
+++ b/mosdef_cassandra/tests/test_moves.py
@@ -445,9 +445,10 @@ class TestMoves(BaseTest):
         assert moves.prob_swap_from_box[0] == 0.5
 
         moves = mc.Moves("gemc", [methane_oplsaa])
-        with pytest.raises(ValueError, match=r"must be a list"):
-            moves.max_volume = 1.0
-        with pytest.raises(ValueError, match=r"must be a list"):
+        moves.max_volume = 1.0
+        assert len(moves.max_volume) == 1
+        assert moves.max_volume[0] == 1.0
+        with pytest.raises(TypeError, match=r"a list with length"):
             moves.max_volume = [1.0, 1.0, 1.0]
         with pytest.raises(TypeError, match=r"of type float"):
             moves.max_volume = [True]
@@ -456,9 +457,7 @@ class TestMoves(BaseTest):
         moves.max_volume = [5000.0]
         assert moves.max_volume[0] == 5000.0
         moves = mc.Moves("gemc_npt", [methane_oplsaa])
-        with pytest.raises(ValueError, match=r"must be a list"):
-            moves.max_volume = 1.0
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"a list with length"):
             moves.max_volume = [1.0, 1.0, 1.0]
         with pytest.raises(TypeError, match=r"of type float"):
             moves.max_volume = [True, 50000.0]

--- a/mosdef_cassandra/tests/test_moves.py
+++ b/mosdef_cassandra/tests/test_moves.py
@@ -499,6 +499,37 @@ class TestMoves(BaseTest):
         moves.prob_regrow_species = [1.0]
         assert moves.prob_regrow_species[0] == 1.0
 
+    def test_cbmc_setters(self, methane_oplsaa):
+        moves = mc.Moves("gemc", [methane_oplsaa])
+        with pytest.raises(TypeError, match=r"must be of type int"):
+            moves.cbmc_n_insert = 12.2
+        with pytest.raises(ValueError, match=r"must be greater than zero"):
+            moves.cbmc_n_insert = -2
+        moves.cbmc_n_insert = 20
+        assert moves.cbmc_n_insert == 20
+        with pytest.raises(TypeError, match=r"must be of type int"):
+            moves.cbmc_n_dihed = 12.2
+        with pytest.raises(ValueError, match=r"must be greater than zero"):
+            moves.cbmc_n_dihed = -2
+        moves.cbmc_n_dihed = 20
+        assert moves.cbmc_n_dihed == 20
+        with pytest.raises(TypeError, match=r"of type float"):
+            moves.cbmc_rcut = [3.0, [3.0]]
+        with pytest.raises(ValueError, match=r"less than zero"):
+            moves.cbmc_rcut = [3.0, -3.0]
+        moves.cbmc_rcut = [4.0, 8.0]
+        assert len(moves.cbmc_rcut) == 2
+        assert moves.cbmc_rcut[0] == 4.0
+        assert moves.cbmc_rcut[1] == 8.0
+        moves.cbmc_rcut = 5.0
+        assert len(moves.cbmc_rcut) == 2
+        assert moves.cbmc_rcut[0] == 5.0
+        assert moves.cbmc_rcut[1] == 5.0
+        moves = mc.Moves("nvt", [methane_oplsaa])
+        moves.cbmc_rcut = 7.0
+        assert len(moves.cbmc_rcut) == 1
+        assert moves.cbmc_rcut[0] == 7.0
+
     def test_print_moves(self, methane_oplsaa):
         """Simple test to make sure moves object is printed"""
 

--- a/mosdef_cassandra/tests/test_writers.py
+++ b/mosdef_cassandra/tests/test_writers.py
@@ -1508,57 +1508,22 @@ class TestInpFunctions(BaseTest):
         )
 
         (system, moves) = onecomp_system
+        moves.cbmc_rcut = [4.5]
+        moves.cbmc_n_insert = 2
+        moves.cbmc_n_dihed = 5
         inp_data = generate_input(
             system=system,
             moves=moves,
             run_type="equilibration",
             run_length=500,
             temperature=300.0,
-            cbmc_kappa_ins=2,
-            cbmc_kappa_dih=5,
-            cbmc_rcut=4.5,
         )
+        print(inp_data)
 
         assert (
             "# CBMC_Info\nkappa_ins 2\nkappa_dih 5\nrcut_cbmc 4.5\n"
             in inp_data
         )
-
-        with pytest.raises(TypeError, match=r"must be an integer"):
-            inp_data = generate_input(
-                system=system,
-                moves=moves,
-                run_type="equilibration",
-                run_length=500,
-                temperature=300.0,
-                cbmc_kappa_ins=2.5,
-                cbmc_kappa_dih=5,
-                cbmc_rcut=4.5,
-            )
-
-        with pytest.raises(TypeError, match=r"must be an integer"):
-            inp_data = generate_input(
-                system=system,
-                moves=moves,
-                run_type="equilibration",
-                run_length=500,
-                temperature=300.0,
-                cbmc_kappa_ins=2,
-                cbmc_kappa_dih=5.5,
-                cbmc_rcut=4.5,
-            )
-
-        with pytest.raises(TypeError, match=r"must be a float"):
-            inp_data = generate_input(
-                system=system,
-                moves=moves,
-                run_type="equilibration",
-                run_length=500,
-                temperature=300.0,
-                cbmc_kappa_ins=2,
-                cbmc_kappa_dih=5,
-                cbmc_rcut=[],
-            )
 
     @pytest.mark.parametrize(
         "typ,value",


### PR DESCRIPTION
The CBMC options are related to the regrowth move. As such, they logically belong in the moves object rather than being specified as separate keyword arguments. This PR brings three new attributes to moves: `cbmc_n_insert`, `cbmc_n_dihed`, and `cbmc_rcut`. 

I also have made the `max_volume` setter accept a float rather than requiring a list of `len(number of boxes)`. If a float is provided and the ensemble is `gemc_npt`, then the selection will automatically apply to both boxes. 