### PR TITLE
Add initial section about restricted insertions

### DIFF
--- a/docs/source/guides/moveset.rst
+++ b/docs/source/guides/moveset.rst
@@ -63,6 +63,16 @@ the following four categories.
 * ``max_translate`` - maximum translation distance
 * ``max_rotate`` - maximum rotation angle
 
+Methods
+++++++++++
+
+The purpose of methods in the ``MoveSet`` class is to add optional
+attributes.  Currently ``MoveSet`` contains the following method:
+
+* ``add_restricted_insertions`` - Adds restricted insertions
+  per-box-per-species which restricts monte carlo particle insertions to a
+  specific region
+
 
 Printing the contents of the MoveSet
 ++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
The aim of this PR is to add documentation for the `add_restricted_insertions` method in the `MoveSet` class.  The initial commit is pretty bare, but I plan to flesh out this section with more information on restricted insertion types.