### PR TITLE
Fix for writing restricted insertions to input file

### DIFF
--- a/mosdef_cassandra/tests/test_writers.py
+++ b/mosdef_cassandra/tests/test_writers.py
@@ -1591,13 +1591,15 @@ class TestInpFunctions(BaseTest):
         if typ == "interface":
             assert (
                 "\nrestricted_insertion {} {:0.1f} {:0.1f}\n".format(
-                    typ, value[0], value[1]
+                    typ, value[0].to_value(), value[1].to_value()
                 )
                 in inp_data
             )
         else:
             assert (
-                "\nrestricted_insertion {} {:0.1f}\n".format(typ, value)
+                "\nrestricted_insertion {} {:0.1f}\n".format(
+                    typ, value.to_value()
+                )
                 in inp_data
             )
 
@@ -1654,13 +1656,15 @@ class TestInpFunctions(BaseTest):
         if typ == "interface":
             assert (
                 "\nrestricted_insertion {} {:0.1f} {:0.1f}\n".format(
-                    typ, value[0], value[1]
+                    typ, value[0].to_value(), value[1].to_value()
                 )
                 in inp_data
             )
         else:
             assert (
-                "\nrestricted_insertion {} {:0.1f}\n".format(typ, value)
+                "\nrestricted_insertion {} {:0.1f}\n".format(
+                    typ, value.to_value()
+                )
                 in inp_data
             )
 

--- a/mosdef_cassandra/writers/inp_functions.py
+++ b/mosdef_cassandra/writers/inp_functions.py
@@ -982,14 +982,17 @@ def get_box_info(boxes, restricted_type, restricted_value):
             for typ, value in zip(restrict_types, restrict_vals):
                 _check_restricted_insertions(box, typ, value)
                 if typ == "interface":
+                    value[0] = value[0].to("angstrom")
+                    value[1] = value[1].to("angstrom")
                     inp_data += """restricted_insertion {} {} {}
                     """.format(
-                        typ, value[0], value[1]
+                        typ, value[0].to_value(), value[1].to_value()
                     )
                 elif typ:
+                    value = value.to("angstrom")
                     inp_data += """restricted_insertion {} {}
                     """.format(
-                        typ, value
+                        typ, value.to_value()
                     )
 
     else:

--- a/mosdef_cassandra/writers/inp_functions.py
+++ b/mosdef_cassandra/writers/inp_functions.py
@@ -982,17 +982,19 @@ def get_box_info(boxes, restricted_type, restricted_value):
             for typ, value in zip(restrict_types, restrict_vals):
                 _check_restricted_insertions(box, typ, value)
                 if typ == "interface":
-                    value[0] = value[0].to("angstrom")
-                    value[1] = value[1].to("angstrom")
+                    # value[0] = value[0].to("angstrom")
+                    # value[1] = value[1].to("angstrom")
                     inp_data += """restricted_insertion {} {} {}
                     """.format(
-                        typ, value[0].to_value(), value[1].to_value()
+                        typ,
+                        value[0].to("angstrom").to_value(),
+                        value[1].to("angstrom").to_value(),
                     )
                 elif typ:
-                    value = value.to("angstrom")
+                    # value = value.to("angstrom")
                     inp_data += """restricted_insertion {} {}
                     """.format(
-                        typ, value.to_value()
+                        typ, value.to("angstrom").to_value()
                     )
 
     else:


### PR DESCRIPTION
Running some systems I realized the restricted insertion values were not being properly converted.  Also, the units were not being pruned.  This is a quick fix to address these bugs.  Will add a couple more tests before review.