### PR TITLE
Add kwarg for angle style

### DIFF
--- a/mosdef_cassandra/examples/ff_files/spce.xml
+++ b/mosdef_cassandra/examples/ff_files/spce.xml
@@ -1,0 +1,16 @@
+<ForceField>
+ <AtomTypes>
+  <Type name="opls_116" class="OW" element="O" mass="15.999" def="O" desc="water oxygen"/>
+  <Type name="opls_117" class="HW" element="H" mass="1.008" def="H" desc="water hydrogen"/>
+ </AtomTypes>
+ <HarmonicBondForce>
+  <Bond class1="OW" class2="HW" length="0.1" k="345000.0"/>
+ </HarmonicBondForce>
+ <HarmonicAngleForce>
+  <Angle class1="HW" class2="OW" class3="HW" angle="1.91061193" k="383.0"/>
+ </HarmonicAngleForce>
+ <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+  <Atom type="opls_116" charge="-0.8476" sigma="0.316557" epsilon="0.650194"/>
+  <Atom type="opls_117" charge="0.4238" sigma="0.1" epsilon="0.0"/>
+ </NonbondedForce>
+</ForceField>

--- a/mosdef_cassandra/examples/ff_files/spce.xml
+++ b/mosdef_cassandra/examples/ff_files/spce.xml
@@ -1,7 +1,7 @@
 <ForceField>
  <AtomTypes>
-  <Type name="opls_116" class="OW" element="O" mass="15.999" def="O" desc="water oxygen"/>
-  <Type name="opls_117" class="HW" element="H" mass="1.008" def="H" desc="water hydrogen"/>
+  <Type name="spce_116" class="OW" element="O" mass="15.999" def="O" desc="SPC/E oxygen" doi="10.1021/j100308a038"/>
+  <Type name="spce_117" class="HW" element="H" mass="1.008" def="H" desc="SPC/E hydrogen" doi="10.1021/j100308a038"/>
  </AtomTypes>
  <HarmonicBondForce>
   <Bond class1="OW" class2="HW" length="0.1" k="345000.0"/>
@@ -10,7 +10,7 @@
   <Angle class1="HW" class2="OW" class3="HW" angle="1.91061193" k="383.0"/>
  </HarmonicAngleForce>
  <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
-  <Atom type="opls_116" charge="-0.8476" sigma="0.316557" epsilon="0.650194"/>
-  <Atom type="opls_117" charge="0.4238" sigma="0.1" epsilon="0.0"/>
+  <Atom type="spce_116" charge="-0.8476" sigma="0.316557" epsilon="0.650194"/>
+  <Atom type="spce_117" charge="0.4238" sigma="0.0" epsilon="0.0"/>
  </NonbondedForce>
 </ForceField>

--- a/mosdef_cassandra/examples/ff_files/spce.xml
+++ b/mosdef_cassandra/examples/ff_files/spce.xml
@@ -1,16 +1,16 @@
 <ForceField>
  <AtomTypes>
-  <Type name="spce_116" class="OW" element="O" mass="15.999" def="O" desc="SPC/E oxygen" doi="10.1021/j100308a038"/>
-  <Type name="spce_117" class="HW" element="H" mass="1.008" def="H" desc="SPC/E hydrogen" doi="10.1021/j100308a038"/>
+  <Type name="spce_o" class="OW" element="O" mass="15.999" def="O" desc="SPC/E oxygen" doi="10.1021/j100308a038"/>
+  <Type name="spce_h" class="HW" element="H" mass="1.008" def="H" desc="SPC/E hydrogen" doi="10.1021/j100308a038"/>
  </AtomTypes>
  <HarmonicBondForce>
-  <Bond class1="OW" class2="HW" length="0.1" k="345000.0"/>
+  <Bond class1="OW" class2="HW" length="0.1" k="502416.0"/>
  </HarmonicBondForce>
  <HarmonicAngleForce>
   <Angle class1="HW" class2="OW" class3="HW" angle="1.91061193" k="383.0"/>
  </HarmonicAngleForce>
  <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
-  <Atom type="spce_116" charge="-0.8476" sigma="0.316557" epsilon="0.650194"/>
-  <Atom type="spce_117" charge="0.4238" sigma="0.0" epsilon="0.0"/>
+  <Atom type="spce_o" charge="-0.8476" sigma="0.316557" epsilon="0.650194"/>
+  <Atom type="spce_h" charge="0.4238" sigma="0.0" epsilon="0.0"/>
  </NonbondedForce>
 </ForceField>

--- a/mosdef_cassandra/examples/mol2_files/spce.mol2
+++ b/mosdef_cassandra/examples/mol2_files/spce.mol2
@@ -1,0 +1,16 @@
+@<TRIPOS>MOLECULE
+RES
+3 2 1 0 1
+SMALL
+NO_CHARGES
+@<TRIPOS>CRYSIN
+    6.3338     5.9426     5.0000    90.0000    90.0000    90.0000  1  1
+@<TRIPOS>ATOM
+       1 O            5.0000     0.0000     0.0000 O             1 RES     
+       2 H            6.0000     0.0000     0.0000 H             1 RES     
+       3 H            4.6662    -0.9426     0.0000 H             1 RES     
+@<TRIPOS>BOND
+       1        1        3 1
+       2        1        2 1
+@<TRIPOS>SUBSTRUCTURE
+       1 RES             1 RESIDUE    0 **** ROOT      0

--- a/mosdef_cassandra/examples/nvt.py
+++ b/mosdef_cassandra/examples/nvt.py
@@ -4,10 +4,10 @@ import mosdef_cassandra as mc
 import unyt as u
 
 
-def run_nvt(custom_args={}):
+def run_nvt(smiles="C", custom_args={}):
 
     # Use mbuild to create molecules
-    methane = mbuild.load("C", smiles=True)
+    molecule = mbuild.load(smiles, smiles=True)
 
     # Create an empty mbuild.Box
     box = mbuild.Box(lengths=[3.0, 3.0, 3.0])
@@ -16,11 +16,11 @@ def run_nvt(custom_args={}):
     oplsaa = foyer.forcefields.load_OPLSAA()
 
     # Use foyer to apply forcefields
-    methane_ff = oplsaa.apply(methane)
+    molecule_ff = oplsaa.apply(molecule)
 
     # Create box and species list
     box_list = [box]
-    species_list = [methane_ff]
+    species_list = [molecule_ff]
 
     # Use Cassandra to insert some initial number of species
     mols_to_add = [[50]]

--- a/mosdef_cassandra/examples/nvt.py
+++ b/mosdef_cassandra/examples/nvt.py
@@ -4,30 +4,11 @@ import numpy as np
 import mosdef_cassandra as mc
 import unyt as u
 from scipy.spatial.transform import Rotation
-from mosdef_cassandra.utils.get_ff import get_ff_path
+from mosdef_cassandra.utils.get_files import get_ff_path, get_mol2_path
 
 
 def run_nvt(custom_args={}):
-
-    # Use mbuild to create molecules
-    molecule = mbuild.load("O", smiles=True)
-    bond_length = 0.1 * u.nm
-    angle = 109.5 * u.degree
-
-    molecule = mbuild.Compound(name="SOL")
-    pos = np.asarray([0.5, 0.0, 0.0])
-    o = mbuild.Compound(name="O", pos=pos)
-    molecule.add(o)
-
-    pos = np.asarray([0.5 + bond_length.to_value(), 0.0, 0.0])
-    h1 = mbuild.Compound(name="H", pos=pos)
-    molecule.add(h1)
-    molecule.add_bond([o, h1])
-
-    pos = o.pos - bond_length.to_value() * rotate2d(o.pos, angle.to_value())
-    h2 = mbuild.Compound(name="H", pos=pos)
-    molecule.add(h2)
-    molecule.add_bond([o, h2])
+    molecule = mbuild.load(get_mol2_path("spce"))
 
     # Create an empty mbuild.Box
     box = mbuild.Box(lengths=[3.0, 3.0, 3.0])
@@ -59,20 +40,6 @@ def run_nvt(custom_args={}):
         temperature=300.0 * u.K,
         **custom_args,
     )
-
-
-def rotate2d(vec, angle):
-    """Rotate a vector `vec` anticlockwise by angle `angle` degrees"""
-
-    angle = np.radians(180.0 - angle)
-
-    xx = np.cos(angle) * vec[0] - np.sin(angle) * vec[1]
-    yy = np.sin(angle) * vec[0] + np.cos(angle) * vec[1]
-
-    vec = np.asarray([xx, yy, 0.0])
-    vec /= np.linalg.norm(vec)
-
-    return vec
 
 
 if __name__ == "__main__":

--- a/mosdef_cassandra/examples/nvt.py
+++ b/mosdef_cassandra/examples/nvt.py
@@ -1,22 +1,42 @@
 import mbuild
 import foyer
+import numpy as np
 import mosdef_cassandra as mc
 import unyt as u
+from scipy.spatial.transform import Rotation
+from mosdef_cassandra.utils.get_ff import get_ff_path
 
 
-def run_nvt(smiles="C", custom_args={}):
+def run_nvt(custom_args={}):
 
     # Use mbuild to create molecules
-    molecule = mbuild.load(smiles, smiles=True)
+    molecule = mbuild.load("O", smiles=True)
+    bond_length = 0.1 * u.nm
+    angle = 109.5 * u.degree
+
+    molecule = mbuild.Compound(name="SOL")
+    pos = np.asarray([0.5, 0.0, 0.0])
+    o = mbuild.Compound(name="O", pos=pos)
+    molecule.add(o)
+
+    pos = np.asarray([0.5 + bond_length.to_value(), 0.0, 0.0])
+    h1 = mbuild.Compound(name="H", pos=pos)
+    molecule.add(h1)
+    molecule.add_bond([o, h1])
+
+    pos = o.pos - bond_length.to_value() * rotate2d(o.pos, angle.to_value())
+    h2 = mbuild.Compound(name="H", pos=pos)
+    molecule.add(h2)
+    molecule.add_bond([o, h2])
 
     # Create an empty mbuild.Box
     box = mbuild.Box(lengths=[3.0, 3.0, 3.0])
 
     # Load forcefields
-    oplsaa = foyer.forcefields.load_OPLSAA()
+    spce = foyer.Forcefield(get_ff_path("spce"))
 
     # Use foyer to apply forcefields
-    molecule_ff = oplsaa.apply(molecule)
+    molecule_ff = spce.apply(molecule)
 
     # Create box and species list
     box_list = [box]
@@ -39,6 +59,20 @@ def run_nvt(smiles="C", custom_args={}):
         temperature=300.0 * u.K,
         **custom_args,
     )
+
+
+def rotate2d(vec, angle):
+    """Rotate a vector `vec` anticlockwise by angle `angle` degrees"""
+
+    angle = np.radians(180.0 - angle)
+
+    xx = np.cos(angle) * vec[0] - np.sin(angle) * vec[1]
+    yy = np.sin(angle) * vec[0] + np.cos(angle) * vec[1]
+
+    vec = np.asarray([xx, yy, 0.0])
+    vec /= np.linalg.norm(vec)
+
+    return vec
 
 
 if __name__ == "__main__":

--- a/mosdef_cassandra/runners/runners.py
+++ b/mosdef_cassandra/runners/runners.py
@@ -48,7 +48,10 @@ def run(system, moveset, run_type, run_length, temperature, **kwargs):
     _check_system(system, moveset)
 
     # Write MCF files
-    write_mcfs(system)
+    if "angle_style" in kwargs:
+        write_mcfs(system, angle_style=kwargs["angle_style"])
+    else:
+        write_mcfs(system)
 
     # Write starting configs (if needed)
     write_configs(system)

--- a/mosdef_cassandra/tests/test_examples.py
+++ b/mosdef_cassandra/tests/test_examples.py
@@ -11,10 +11,11 @@ from mosdef_cassandra.tests.base_test import BaseTest
 
 
 class TestExamples(BaseTest):
-    def test_run_nvt(self):
+    @pytest.mark.parametrize("smiles", ["C"])
+    def test_run_nvt(self, smiles):
         with temporary_directory() as tmp_dir:
             with temporary_cd(tmp_dir):
-                ex.run_nvt()
+                ex.run_nvt(smiles=smiles)
                 log_files = sorted(
                     glob.glob("./mosdef_cassandra*.log"), key=os.path.getmtime
                 )
@@ -41,7 +42,7 @@ class TestExamples(BaseTest):
                 with pytest.raises(
                     CassandraRuntimeError, match=r"Cassandra exited with"
                 ):
-                    ex.run_nvt(kwargs)
+                    ex.run_nvt(custom_args=kwargs)
 
     def test_run_npt(self):
         with temporary_directory() as tmp_dir:

--- a/mosdef_cassandra/tests/test_examples.py
+++ b/mosdef_cassandra/tests/test_examples.py
@@ -11,10 +11,11 @@ from mosdef_cassandra.tests.base_test import BaseTest
 
 
 class TestExamples(BaseTest):
-    def test_run_nvt(self):
+    @pytest.mark.parametrize("custom_args", [{"angle_style": ["fixed"]}, {}])
+    def test_run_nvt(self, custom_args):
         with temporary_directory() as tmp_dir:
             with temporary_cd(tmp_dir):
-                ex.run_nvt()
+                ex.run_nvt(custom_args=custom_args)
                 log_files = sorted(
                     glob.glob("./mosdef_cassandra*.log"), key=os.path.getmtime
                 )

--- a/mosdef_cassandra/tests/test_examples.py
+++ b/mosdef_cassandra/tests/test_examples.py
@@ -11,11 +11,10 @@ from mosdef_cassandra.tests.base_test import BaseTest
 
 
 class TestExamples(BaseTest):
-    @pytest.mark.parametrize("smiles", ["C"])
-    def test_run_nvt(self, smiles):
+    def test_run_nvt(self):
         with temporary_directory() as tmp_dir:
             with temporary_cd(tmp_dir):
-                ex.run_nvt(smiles=smiles)
+                ex.run_nvt()
                 log_files = sorted(
                     glob.glob("./mosdef_cassandra*.log"), key=os.path.getmtime
                 )

--- a/mosdef_cassandra/tests/test_writers.py
+++ b/mosdef_cassandra/tests/test_writers.py
@@ -5,6 +5,8 @@ import mosdef_cassandra as mc
 import unyt as u
 from mosdef_cassandra.tests.base_test import BaseTest
 from mosdef_cassandra.writers.inp_functions import generate_input
+from mosdef_cassandra.writers.writers import write_mcfs
+from mosdef_cassandra.utils.tempdir import *
 
 
 class TestInpFunctions(BaseTest):
@@ -1693,3 +1695,24 @@ class TestInpFunctions(BaseTest):
                 temperature=300.0 * u.K,
                 pressure=1 * u.bar,
             )
+
+    @pytest.mark.parametrize(
+        "angle_style", [["fixed"], ["harmonic"], "fixed", "harmonic"]
+    )
+    def test_onecomp_angle_style(self, onecomp_system, angle_style):
+        with temporary_directory() as tmp_dir:
+            with temporary_cd(tmp_dir):
+                (system, moveset) = onecomp_system
+                write_mcfs(system, angle_style=angle_style)
+
+    @pytest.mark.parametrize("angle_style", ["fixed", "harmonic"])
+    def test_twocomp_angle_style(self, twocomp_system, angle_style):
+        with temporary_directory() as tmp_dir:
+            with temporary_cd(tmp_dir):
+                (system, moveset) = twocomp_system
+                write_mcfs(system, angle_style=[angle_style, angle_style])
+
+    def test_angle_style_error(self, onecomp_system):
+        (system, moveset) = onecomp_system
+        with pytest.raises(ValueError, match="Invalid"):
+            write_mcfs(system, angle_style=["charmm"])

--- a/mosdef_cassandra/utils/get_ff.py
+++ b/mosdef_cassandra/utils/get_ff.py
@@ -1,0 +1,12 @@
+import os
+from pkg_resources import resource_filename
+
+
+def get_ff_path(ff_name):
+    """Get the path to a force field xml file in the examples
+    directory"""
+    ff_path = resource_filename(
+        "mosdef_cassandra", os.path.join("examples/ff_files", ff_name + ".xml")
+    )
+
+    return ff_path

--- a/mosdef_cassandra/utils/get_files.py
+++ b/mosdef_cassandra/utils/get_files.py
@@ -1,0 +1,23 @@
+import os
+from pkg_resources import resource_filename
+
+
+def get_ff_path(ff_name):
+    """Get the path to a force field xml file in the examples
+    directory"""
+    ff_path = resource_filename(
+        "mosdef_cassandra", os.path.join("examples/ff_files", ff_name + ".xml")
+    )
+
+    return ff_path
+
+
+def get_mol2_path(molecule_name):
+    """Get the path to a mol2 file in the examples
+    directory"""
+    mol2_path = resource_filename(
+        "mosdef_cassandra",
+        os.path.join("examples/mol2_files", molecule_name + ".mol2"),
+    )
+
+    return mol2_path

--- a/mosdef_cassandra/writers/inp_functions.py
+++ b/mosdef_cassandra/writers/inp_functions.py
@@ -1950,6 +1950,7 @@ def _get_possible_kwargs(desc=False):
         "cbmc_rcut": "unyt_array or unyt_quantity with `length` units, cutoff for CBMC",
         "restart": "boolean, restart from checkpoint file",
         "restart_name": "name of checkpoint file to restart from",
+        "angle_style": "list of str, angle style for each species",
     }
     if desc:
         return valid_kwargs

--- a/mosdef_cassandra/writers/writers.py
+++ b/mosdef_cassandra/writers/writers.py
@@ -6,7 +6,10 @@ import mosdef_cassandra
 from mosdef_cassandra.writers.inp_functions import generate_input
 
 
-def write_mcfs(system):
+def write_mcfs(system, angle_style="harmonic"):
+
+    if angle_style == "harmonic":
+        angle_style = [angle_style] * len(system.species_topologies)
 
     if not isinstance(system, mosdef_cassandra.System):
         raise TypeError('"system" must be of type ' "mosdef_cassandra.System")
@@ -36,7 +39,7 @@ def write_mcfs(system):
         write_mcf(
             species,
             mcf_name,
-            angle_style="harmonic",
+            angle_style=angle_style[species_count],
             dihedral_style=dihedral_style,
         )
 

--- a/mosdef_cassandra/writers/writers.py
+++ b/mosdef_cassandra/writers/writers.py
@@ -7,9 +7,22 @@ from mosdef_cassandra.writers.inp_functions import generate_input
 
 
 def write_mcfs(system, angle_style="harmonic"):
-
-    if angle_style == "harmonic":
+    """ Write a MCF file for a given mosdef_cassandra.System
+    Parameters
+    ----------
+    system : mosdef_cassandra.System
+        System to simulate in Cassandra
+    angle_style : str, default="harmonic"
+        Angle style for the system, valid arguments: "harmonic", "fixed"
+    """
+    if type(angle_style) == str:
         angle_style = [angle_style] * len(system.species_topologies)
+
+    for astyle in angle_style:
+        if astyle not in ["harmonic", "fixed"]:
+            raise ValueError(
+                'Invalid "angle_style" {} given.'.format(angle_style)
+            )
 
     if not isinstance(system, mosdef_cassandra.System):
         raise TypeError('"system" must be of type ' "mosdef_cassandra.System")


### PR DESCRIPTION
Addition of `angle_style` kwarg to specify if angles should be `fixed` or `harmonic`.  Right now, I'm trying to figure out how to test this feature.  I initially added this as a kwarg for some of the tests with the methane molecule, but I don't think OPLS methane is supposed to have fixed angles.  As a result, the simulation fails.