### PR TITLE
Make unyt checking more robust and bug fixes

### DIFF
--- a/mosdef_cassandra/core/moveset.py
+++ b/mosdef_cassandra/core/moveset.py
@@ -131,7 +131,7 @@ class MoveSet(object):
         # Set the default CBMC options
         self.cbmc_n_insert = 10
         self.cbmc_n_dihed = 10
-        self.cbmc_rcut = 6.0
+        self.cbmc_rcut = 6.0 * u.angstrom
 
         # Remaining options are per-species
         self.max_dihedral = [0.0 * u.degree] * self._n_species
@@ -748,27 +748,26 @@ class MoveSet(object):
 
     @cbmc_rcut.setter
     def cbmc_rcut(self, cbmc_rcut):
-        if type(cbmc_rcut) not in (list, float, int):
+        if not isinstance(cbmc_rcut, (list, u.unyt_array)):
             raise TypeError(
-                "cbmc_rcut must be a float, or, optionally, "
+                "cbmc_rcut must be a unyt array, or, optionally, "
                 "a list with length (number of boxes)"
             )
         if type(cbmc_rcut) == list:
             if len(cbmc_rcut) != self._n_boxes:
                 raise TypeError(
-                    "cbmc_rcut must be a float or a list with length "
+                    "cbmc_rcut must be a unyt array or a list with length "
                     "(number of boxes)"
                 )
         else:
             cbmc_rcut = [cbmc_rcut] * self._n_boxes
 
         for rcut in cbmc_rcut:
-            if type(rcut) not in (float, int):
-                raise TypeError("cbmc_rcut values must be of type float")
-            if rcut < 0.0:
+            validate_unit(rcut, dimensions.length)
+            if rcut.to_value() < 0.0:
                 raise ValueError("cbmc_rcut cannot be less than zero.")
 
-        self._cbmc_rcut = [float(rcut) for rcut in cbmc_rcut]
+        self._cbmc_rcut = [rcut for rcut in cbmc_rcut]
 
     def print(self):
         """Print the current contents of the MoveSet"""

--- a/mosdef_cassandra/core/moveset.py
+++ b/mosdef_cassandra/core/moveset.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from unyt import dimensions
-from mosdef_cassandra.utils.units import validate_unit
+from mosdef_cassandra.utils.units import validate_unit, validate_unit_list
 
 import parmed
 import warnings
@@ -472,30 +472,41 @@ class MoveSet(object):
 
     @max_translate.setter
     def max_translate(self, max_translate):
-
-        if (
-            not isinstance(max_translate, list)
-            or len(max_translate) != self._n_boxes
-        ):
-            raise ValueError(
-                "max_translate must be a list with shape "
-                "(number of boxes, number of species)"
-            )
-        for max_translate_box in max_translate:
-            if (
-                not isinstance(max_translate_box, list)
-                or len(max_translate_box) != self._n_species
-            ):
+        max_translate = validate_unit_list(
+            max_translate,
+            (self._n_boxes, self._n_species),
+            dimensions.length,
+            "max_translate",
+        )
+        for max_val in max_translate.flatten():
+            if max_val.to_value() < 0.0:
                 raise ValueError(
-                    "max_translate must be a list with "
-                    "shape (number of boxes, number of species)"
+                    "Max translation values cannot " "be less than zero"
                 )
-            for max_val in max_translate_box:
-                validate_unit(max_val, dimensions.length)
-                if max_val.to_value() < 0.0:
-                    raise ValueError(
-                        "Max translation values cannot " "be less than zero"
-                    )
+
+        #        if (
+        #            not isinstance(max_translate, list)
+        #            or len(max_translate) != self._n_boxes
+        #        ):
+        #            raise ValueError(
+        #                "max_translate must be a list with shape "
+        #                "(number of boxes, number of species)"
+        #            )
+        #        for max_translate_box in max_translate:
+        #            if (
+        #                not isinstance(max_translate_box, list)
+        #                or len(max_translate_box) != self._n_species
+        #            ):
+        #                raise ValueError(
+        #                    "max_translate must be a list with "
+        #                    "shape (number of boxes, number of species)"
+        #                )
+        #            for max_val in max_translate_box:
+        #                validate_unit(max_val, dimensions.length)
+        #                if max_val.to_value() < 0.0:
+        #                    raise ValueError(
+        #                        "Max translation values cannot " "be less than zero"
+        #                    )
 
         self._max_translate = max_translate
 

--- a/mosdef_cassandra/core/moveset.py
+++ b/mosdef_cassandra/core/moveset.py
@@ -319,8 +319,7 @@ class MoveSet(object):
     @prob_translate.setter
     def prob_translate(self, prob_translate):
         prob_translate = self._validate_probability(
-            prob_translate,
-            "prob_translate",
+            prob_translate, "prob_translate",
         )
         self._prob_translate = prob_translate
 
@@ -330,10 +329,7 @@ class MoveSet(object):
 
     @prob_rotate.setter
     def prob_rotate(self, prob_rotate):
-        prob_rotate = self._validate_probability(
-            prob_rotate,
-            "prob_rotate",
-        )
+        prob_rotate = self._validate_probability(prob_rotate, "prob_rotate",)
         self._prob_rotate = prob_rotate
 
     @property
@@ -342,10 +338,7 @@ class MoveSet(object):
 
     @prob_angle.setter
     def prob_angle(self, prob_angle):
-        prob_angle = self._validate_probability(
-            prob_angle,
-            "prob_angle",
-        )
+        prob_angle = self._validate_probability(prob_angle, "prob_angle",)
         self._prob_angle = prob_angle
 
     @property
@@ -355,8 +348,7 @@ class MoveSet(object):
     @prob_dihedral.setter
     def prob_dihedral(self, prob_dihedral):
         prob_dihedral = self._validate_probability(
-            prob_dihedral,
-            "prob_dihedral",
+            prob_dihedral, "prob_dihedral",
         )
         self._prob_dihedral = prob_dihedral
 
@@ -366,10 +358,7 @@ class MoveSet(object):
 
     @prob_regrow.setter
     def prob_regrow(self, prob_regrow):
-        prob_regrow = self._validate_probability(
-            prob_regrow,
-            "prob_regrow",
-        )
+        prob_regrow = self._validate_probability(prob_regrow, "prob_regrow",)
         self._prob_regrow = prob_regrow
 
     @property
@@ -378,10 +367,7 @@ class MoveSet(object):
 
     @prob_volume.setter
     def prob_volume(self, prob_volume):
-        prob_volume = self._validate_probability(
-            prob_volume,
-            "prob_volume",
-        )
+        prob_volume = self._validate_probability(prob_volume, "prob_volume",)
         if prob_volume > 0.0:
             if self.ensemble == "nvt" or self.ensemble == "gcmc":
                 raise ValueError(
@@ -409,10 +395,7 @@ class MoveSet(object):
 
     @prob_insert.setter
     def prob_insert(self, prob_insert):
-        prob_insert = self._validate_probability(
-            prob_insert,
-            "prob_insert",
-        )
+        prob_insert = self._validate_probability(prob_insert, "prob_insert",)
         if self.ensemble != "gcmc" and prob_insert != 0.0:
             raise ValueError(
                 "Ensemble is {}. Insertion probability "
@@ -431,10 +414,7 @@ class MoveSet(object):
 
     @prob_swap.setter
     def prob_swap(self, prob_swap):
-        prob_swap = self._validate_probability(
-            prob_swap,
-            "prob_swap",
-        )
+        prob_swap = self._validate_probability(prob_swap, "prob_swap",)
         if self.ensemble != "gemc" and self.ensemble != "gemc_npt":
             if prob_swap != 0.0:
                 raise ValueError(
@@ -482,7 +462,10 @@ class MoveSet(object):
             "max_rotate",
         )
         for max_val in max_rotate.flatten():
-            if max_val.to_value("degree") < 0.0 or max_val.to_value("degree") > 360.0:
+            if (
+                max_val.to_value("degree") < 0.0
+                or max_val.to_value("degree") > 360.0
+            ):
                 raise ValueError(
                     "Max rotation values must be between 0.0 and 360.0 degrees."
                 )
@@ -495,13 +478,13 @@ class MoveSet(object):
     @max_dihedral.setter
     def max_dihedral(self, max_dihedral):
         max_dihedral = validate_unit_list(
-            max_dihedral,
-            (self._n_species,),
-            dimensions.angle,
-            "max_dihedral",
+            max_dihedral, (self._n_species,), dimensions.angle, "max_dihedral",
         )
         for max_val in max_dihedral:
-            if max_val.to_value("degree") < 0.0 or max_val.to_value("degree") > 360.0:
+            if (
+                max_val.to_value("degree") < 0.0
+                or max_val.to_value("degree") > 360.0
+            ):
                 raise ValueError(
                     "Max dihedral rotation values must be between 0.0 and 360.0 degrees."
                 )
@@ -525,8 +508,7 @@ class MoveSet(object):
         validated_prob_swap_from_box = []
         for prob_swap in prob_swap_from_box:
             prob_swap = self._validate_probability(
-                prob_swap,
-                "prob_swap_from_box",
+                prob_swap, "prob_swap_from_box",
             )
             validated_prob_swap_from_box.append(prob_swap)
         self._prob_swap_from_box = validated_prob_swap_from_box
@@ -542,17 +524,14 @@ class MoveSet(object):
                 max_volume = [max_volume] * self._n_boxes
             else:
                 max_volume = [max_volume]
-        
+
         if self.ensemble == "gemc_npt":
             shape = (self._n_boxes,)
         else:
-            shape = (1, )
+            shape = (1,)
 
         max_volume = validate_unit_list(
-            max_volume,
-            shape,
-            dimensions.length**3,
-            "max_volume",
+            max_volume, shape, dimensions.length ** 3, "max_volume",
         )
         for max_vol in max_volume.flatten():
             if max_vol < 0.0:
@@ -600,8 +579,7 @@ class MoveSet(object):
         validated_prob_swap_species = []
         for prob_swap in prob_swap_species:
             prob_swap = self._validate_probability(
-                prob_swap,
-                "prob_swap_species",
+                prob_swap, "prob_swap_species",
             )
             validated_prob_swap_species.append(prob_swap)
         self._prob_swap_species = validated_prob_swap_species
@@ -623,8 +601,7 @@ class MoveSet(object):
         validated_prob_regrow_species = []
         for prob_regrow in prob_regrow_species:
             prob_regrow = self._validate_probability(
-                prob_regrow,
-                "prob_regrow"
+                prob_regrow, "prob_regrow"
             )
             validated_prob_regrow_species.append(prob_regrow)
         self._prob_regrow_species = validated_prob_regrow_species
@@ -662,10 +639,7 @@ class MoveSet(object):
         if type(cbmc_rcut) not in (list, u.unyt_array):
             cbmc_rcut = [cbmc_rcut] * self._n_boxes
         cbmc_rcut = validate_unit_list(
-            cbmc_rcut,
-            (self._n_boxes,),
-            dimensions.length,
-            "cbmc_rcut",
+            cbmc_rcut, (self._n_boxes,), dimensions.length, "cbmc_rcut",
         )
 
         for rcut in cbmc_rcut.flatten():
@@ -842,5 +816,3 @@ def _check_restriction_type(restriction_type, restriction_value):
                 " single argument of type `unyt_array"
                 " should be passed".format(restriction_type)
             )
-
-

--- a/mosdef_cassandra/core/moveset.py
+++ b/mosdef_cassandra/core/moveset.py
@@ -318,12 +318,10 @@ class MoveSet(object):
 
     @prob_translate.setter
     def prob_translate(self, prob_translate):
-        if type(prob_translate) not in (float, int):
-            raise TypeError("prob_translate must be of type float")
-        else:
-            prob_translate = float(prob_translate)
-        if prob_translate < 0.0 or prob_translate > 1.0:
-            raise ValueError("Probability must be between 0.0 and 1.0.")
+        prob_translate = self._validate_probability(
+            prob_translate,
+            "prob_translate",
+        )
         self._prob_translate = prob_translate
 
     @property
@@ -332,12 +330,10 @@ class MoveSet(object):
 
     @prob_rotate.setter
     def prob_rotate(self, prob_rotate):
-        if type(prob_rotate) not in (float, int):
-            raise TypeError("prob_rotate must be of type float")
-        else:
-            prob_rotate = float(prob_rotate)
-        if prob_rotate < 0.0 or prob_rotate > 1.0:
-            raise ValueError("Probability must be between 0.0 and 1.0.")
+        prob_rotate = self._validate_probability(
+            prob_rotate,
+            "prob_rotate",
+        )
         self._prob_rotate = prob_rotate
 
     @property
@@ -346,12 +342,10 @@ class MoveSet(object):
 
     @prob_angle.setter
     def prob_angle(self, prob_angle):
-        if type(prob_angle) not in (float, int):
-            raise TypeError("prob_angle must be of type float")
-        else:
-            prob_angle = float(prob_angle)
-        if prob_angle < 0.0 or prob_angle > 1.0:
-            raise ValueError("Probability must be between 0.0 and 1.0.")
+        prob_angle = self._validate_probability(
+            prob_angle,
+            "prob_angle",
+        )
         self._prob_angle = prob_angle
 
     @property
@@ -360,12 +354,10 @@ class MoveSet(object):
 
     @prob_dihedral.setter
     def prob_dihedral(self, prob_dihedral):
-        if type(prob_dihedral) not in (float, int):
-            raise TypeError("prob_dihedral must be of type float")
-        else:
-            prob_dihedral = float(prob_dihedral)
-        if prob_dihedral < 0.0 or prob_dihedral > 1.0:
-            raise ValueError("Probability must be between 0.0 and 1.0.")
+        prob_dihedral = self._validate_probability(
+            prob_dihedral,
+            "prob_dihedral",
+        )
         self._prob_dihedral = prob_dihedral
 
     @property
@@ -374,12 +366,10 @@ class MoveSet(object):
 
     @prob_regrow.setter
     def prob_regrow(self, prob_regrow):
-        if type(prob_regrow) not in (float, int):
-            raise TypeError("prob_regrow must be of type float")
-        else:
-            prob_regrow = float(prob_regrow)
-        if prob_regrow < 0.0 or prob_regrow > 1.0:
-            raise ValueError("Probability must be between 0.0 and 1.0.")
+        prob_regrow = self._validate_probability(
+            prob_regrow,
+            "prob_regrow",
+        )
         self._prob_regrow = prob_regrow
 
     @property
@@ -388,12 +378,10 @@ class MoveSet(object):
 
     @prob_volume.setter
     def prob_volume(self, prob_volume):
-        if type(prob_volume) not in (float, int):
-            raise TypeError("prob_volume must be of type float")
-        else:
-            prob_volume = float(prob_volume)
-        if prob_volume < 0.0 or prob_volume > 1.0:
-            raise ValueError("Probability must be between 0.0 and 1.0.")
+        prob_volume = self._validate_probability(
+            prob_volume,
+            "prob_volume",
+        )
         if prob_volume > 0.0:
             if self.ensemble == "nvt" or self.ensemble == "gcmc":
                 raise ValueError(
@@ -421,12 +409,10 @@ class MoveSet(object):
 
     @prob_insert.setter
     def prob_insert(self, prob_insert):
-        if type(prob_insert) not in (float, int):
-            raise TypeError("prob_insert must be of type float")
-        else:
-            prob_insert = float(prob_insert)
-        if prob_insert < 0.0 or prob_insert > 1.0:
-            raise ValueError("Probability must be between 0.0 and 1.0.")
+        prob_insert = self._validate_probability(
+            prob_insert,
+            "prob_insert",
+        )
         if self.ensemble != "gcmc" and prob_insert != 0.0:
             raise ValueError(
                 "Ensemble is {}. Insertion probability "
@@ -445,12 +431,10 @@ class MoveSet(object):
 
     @prob_swap.setter
     def prob_swap(self, prob_swap):
-        if type(prob_swap) not in (float, int):
-            raise TypeError("prob_swap must be of type float")
-        else:
-            prob_swap = float(prob_swap)
-        if prob_swap < 0.0 or prob_swap > 1.0:
-            raise ValueError("Probability must be between 0.0 and 1.0.")
+        prob_swap = self._validate_probability(
+            prob_swap,
+            "prob_swap",
+        )
         if self.ensemble != "gemc" and self.ensemble != "gemc_npt":
             if prob_swap != 0.0:
                 raise ValueError(
@@ -481,33 +465,8 @@ class MoveSet(object):
         for max_val in max_translate.flatten():
             if max_val.to_value() < 0.0:
                 raise ValueError(
-                    "Max translation values cannot " "be less than zero"
+                    "Max translation values cannot be less than zero"
                 )
-
-        #        if (
-        #            not isinstance(max_translate, list)
-        #            or len(max_translate) != self._n_boxes
-        #        ):
-        #            raise ValueError(
-        #                "max_translate must be a list with shape "
-        #                "(number of boxes, number of species)"
-        #            )
-        #        for max_translate_box in max_translate:
-        #            if (
-        #                not isinstance(max_translate_box, list)
-        #                or len(max_translate_box) != self._n_species
-        #            ):
-        #                raise ValueError(
-        #                    "max_translate must be a list with "
-        #                    "shape (number of boxes, number of species)"
-        #                )
-        #            for max_val in max_translate_box:
-        #                validate_unit(max_val, dimensions.length)
-        #                if max_val.to_value() < 0.0:
-        #                    raise ValueError(
-        #                        "Max translation values cannot " "be less than zero"
-        #                    )
-
         self._max_translate = max_translate
 
     @property
@@ -516,31 +475,17 @@ class MoveSet(object):
 
     @max_rotate.setter
     def max_rotate(self, max_rotate):
-
-        if (
-            not isinstance(max_rotate, list)
-            or len(max_rotate) != self._n_boxes
-        ):
-            raise ValueError(
-                "max_rotate must be a list with shape "
-                "(number of boxes, number of species)"
-            )
-        for max_rotate_box in max_rotate:
-            if (
-                not isinstance(max_rotate_box, list)
-                or len(max_rotate_box) != self._n_species
-            ):
+        max_rotate = validate_unit_list(
+            max_rotate,
+            (self._n_boxes, self._n_species),
+            dimensions.angle,
+            "max_rotate",
+        )
+        for max_val in max_rotate.flatten():
+            if max_val.to_value("degree") < 0.0 or max_val.to_value("degree") > 360.0:
                 raise ValueError(
-                    "max_rotate must be a list with "
-                    "shape (number of boxes, number of species)"
+                    "Max rotation values must be between 0.0 and 360.0 degrees."
                 )
-            for max_val in max_rotate_box:
-                validate_unit(max_val, dimensions.angle)
-                if max_val.to_value() < 0.0:
-                    raise ValueError(
-                        "Max rotation values cannot " "be less than zero"
-                    )
-
         self._max_rotate = max_rotate
 
     @property
@@ -549,28 +494,17 @@ class MoveSet(object):
 
     @max_dihedral.setter
     def max_dihedral(self, max_dihedral):
-
-        if (
-            not isinstance(max_dihedral, list)
-            or len(max_dihedral) != self._n_species
-        ):
-            raise ValueError(
-                "max_dihedral must be a list with length "
-                "(number of species)"
-            )
+        max_dihedral = validate_unit_list(
+            max_dihedral,
+            (self._n_species,),
+            dimensions.angle,
+            "max_dihedral",
+        )
         for max_val in max_dihedral:
-            if not isinstance(max_val, u.unyt_array):
-                raise TypeError("Max dihedral values must be a unyt array")
-            if (
-                max_val.to("degree").to_value() < 0.0
-                or max_val.to("degree").to_value() > 360.0
-            ):
+            if max_val.to_value("degree") < 0.0 or max_val.to_value("degree") > 360.0:
                 raise ValueError(
-                    "Max dihedral values cannot "
-                    "be less than zero"
-                    " or greater than 360 degrees"
+                    "Max dihedral rotation values must be between 0.0 and 360.0 degrees."
                 )
-
         self._max_dihedral = max_dihedral
 
     @property
@@ -584,25 +518,18 @@ class MoveSet(object):
             not isinstance(prob_swap_from_box, list)
             or len(prob_swap_from_box) != self._n_boxes
         ):
-            raise ValueError(
+            raise TypeError(
                 "prob_swap_from_box must be a list with length "
                 "(number of boxes)"
             )
+        validated_prob_swap_from_box = []
         for prob_swap in prob_swap_from_box:
-            if type(prob_swap) not in (float, int):
-                raise TypeError(
-                    "Probability of swapping from a box "
-                    "must be of type float"
-                )
-            else:
-                prob_swap = float(prob_swap)
-            if prob_swap < 0.0:
-                raise ValueError(
-                    "Probability of swapping from a box "
-                    "cannot be less than zero"
-                )
-
-        self._prob_swap_from_box = prob_swap_from_box
+            prob_swap = self._validate_probability(
+                prob_swap,
+                "prob_swap_from_box",
+            )
+            validated_prob_swap_from_box.append(prob_swap)
+        self._prob_swap_from_box = validated_prob_swap_from_box
 
     @property
     def max_volume(self):
@@ -611,37 +538,25 @@ class MoveSet(object):
     @max_volume.setter
     def max_volume(self, max_volume):
         if type(max_volume) not in (list, u.unyt_array):
-            raise TypeError(
-                "max_volume must be a unyt array, or, optionally, "
-                "a list with length (number of boxes)"
-            )
-        if type(max_volume) == list:
-            if self.ensemble == "gemc_npt":
-                if len(max_volume) != self._n_boxes:
-                    raise TypeError(
-                        "max_volume must be a unyt array or a list with length "
-                        "(number of boxes) for gemc_npt"
-                    )
-            else:
-                if len(max_volume) != 1:
-                    raise TypeError(
-                        "max_volume must be a unyt_array or a list with length "
-                        "1 for all ensembles except gemc_npt"
-                    )
-        else:
             if self.ensemble == "gemc_npt":
                 max_volume = [max_volume] * self._n_boxes
             else:
                 max_volume = [max_volume]
+        
+        if self.ensemble == "gemc_npt":
+            shape = (self._n_boxes,)
+        else:
+            shape = (1, )
 
-        for max_vol in max_volume:
-            validate_unit(max_vol, dimensions.volume)
-            # if type(max_vol) not in (float, int):
-            #    raise TypeError("max_volume values must be of type float")
+        max_volume = validate_unit_list(
+            max_volume,
+            shape,
+            dimensions.length**3,
+            "max_volume",
+        )
+        for max_vol in max_volume.flatten():
             if max_vol < 0.0:
                 raise ValueError("max_volume cannot be less than zero.")
-
-        # self._max_volume = [float(max_vol) for max_vol in max_volume]
         self._max_volume = max_volume
 
     @property
@@ -655,7 +570,7 @@ class MoveSet(object):
             not isinstance(insertable, list)
             or len(insertable) != self._n_species
         ):
-            raise ValueError(
+            raise TypeError(
                 "insertable must be a list with length " "(number of species)"
             )
         for insert in insertable:
@@ -678,25 +593,18 @@ class MoveSet(object):
             not isinstance(prob_swap_species, list)
             or len(prob_swap_species) != self._n_species
         ):
-            raise ValueError(
+            raise TypeError(
                 "prob_swap_species must be a list with length "
                 "(number of species)"
             )
+        validated_prob_swap_species = []
         for prob_swap in prob_swap_species:
-            if type(prob_swap) not in (float, int):
-                raise TypeError(
-                    "Probability of swapping a species "
-                    "must be of type float"
-                )
-            else:
-                prob_swap = float(prob_swap)
-            if prob_swap < 0.0:
-                raise ValueError(
-                    "Probability of swapping a species "
-                    "cannot be less than zero"
-                )
-
-        self._prob_swap_species = prob_swap_species
+            prob_swap = self._validate_probability(
+                prob_swap,
+                "prob_swap_species",
+            )
+            validated_prob_swap_species.append(prob_swap)
+        self._prob_swap_species = validated_prob_swap_species
 
     @property
     def prob_regrow_species(self):
@@ -704,30 +612,22 @@ class MoveSet(object):
 
     @prob_regrow_species.setter
     def prob_regrow_species(self, prob_regrow_species):
-
         if (
             not isinstance(prob_regrow_species, list)
             or len(prob_regrow_species) != self._n_species
         ):
-            raise ValueError(
+            raise TypeError(
                 "prob_regrow_species must be a list with length "
                 "(number of species)"
             )
+        validated_prob_regrow_species = []
         for prob_regrow in prob_regrow_species:
-            if type(prob_regrow) not in (float, int):
-                raise TypeError(
-                    "Probability of regrowing a species "
-                    "must be of type float"
-                )
-            else:
-                prob_regrow = float(prob_regrow)
-            if prob_regrow < 0.0:
-                raise ValueError(
-                    "Probability of regrowing a species "
-                    "cannot be less than zero"
-                )
-
-        self._prob_regrow_species = prob_regrow_species
+            prob_regrow = self._validate_probability(
+                prob_regrow,
+                "prob_regrow"
+            )
+            validated_prob_regrow_species.append(prob_regrow)
+        self._prob_regrow_species = validated_prob_regrow_species
 
     @property
     def cbmc_n_insert(self):
@@ -759,26 +659,20 @@ class MoveSet(object):
 
     @cbmc_rcut.setter
     def cbmc_rcut(self, cbmc_rcut):
-        if not isinstance(cbmc_rcut, (list, u.unyt_array)):
-            raise TypeError(
-                "cbmc_rcut must be a unyt array, or, optionally, "
-                "a list with length (number of boxes)"
-            )
-        if type(cbmc_rcut) == list:
-            if len(cbmc_rcut) != self._n_boxes:
-                raise TypeError(
-                    "cbmc_rcut must be a unyt array or a list with length "
-                    "(number of boxes)"
-                )
-        else:
+        if type(cbmc_rcut) not in (list, u.unyt_array):
             cbmc_rcut = [cbmc_rcut] * self._n_boxes
+        cbmc_rcut = validate_unit_list(
+            cbmc_rcut,
+            (self._n_boxes,),
+            dimensions.length,
+            "cbmc_rcut",
+        )
 
-        for rcut in cbmc_rcut:
-            validate_unit(rcut, dimensions.length)
+        for rcut in cbmc_rcut.flatten():
             if rcut.to_value() < 0.0:
                 raise ValueError("cbmc_rcut cannot be less than zero.")
 
-        self._cbmc_rcut = [rcut for rcut in cbmc_rcut]
+        self._cbmc_rcut = cbmc_rcut
 
     def print(self):
         """Print the current contents of the MoveSet"""
@@ -911,6 +805,15 @@ CBMC selections:
 
         print(contents)
 
+    def _validate_probability(self, probability, name):
+        if type(probability) not in (float, int):
+            raise TypeError(f"{name} must be of type float")
+        else:
+            probability = float(probability)
+        if probability < 0.0 or probability > 1.0:
+            raise ValueError(f"{name} must be between 0.0 and 1.0.")
+        return probability
+
 
 def _check_restriction_type(restriction_type, restriction_value):
     valid_restrict_types = ["sphere", "cylinder", "slitpore", "interface"]
@@ -939,3 +842,5 @@ def _check_restriction_type(restriction_type, restriction_value):
                 " single argument of type `unyt_array"
                 " should be passed".format(restriction_type)
             )
+
+

--- a/mosdef_cassandra/tests/test_kwarg_units.py
+++ b/mosdef_cassandra/tests/test_kwarg_units.py
@@ -5,35 +5,51 @@ import mosdef_cassandra as mc
 from unyt import dimensions
 from unyt.array import allclose_units
 from mosdef_cassandra.tests.base_test import BaseTest
-from mosdef_cassandra.writers.inp_functions import _check_kwarg_units_helper, _convert_kwarg_units_helper
+from mosdef_cassandra.writers.inp_functions import (
+    _check_kwarg_units_helper,
+    _convert_kwarg_units_helper,
+)
 from mosdef_cassandra.utils.units import validate_unit_list
 
 
 class TestKwargUnits(BaseTest):
-
     def test_check_kwarg_units_helper(self):
         kwargs = {
-            "example_cutoff" : 5.5 * u.angstrom,
-            "example_cutoff_list" : [5.5 * u.angstrom, 6.0 * u.angstrom]
+            "example_cutoff": 5.5 * u.angstrom,
+            "example_cutoff_list": [5.5 * u.angstrom, 6.0 * u.angstrom],
         }
         _check_kwarg_units_helper(kwargs, "example_cutoff", dimensions.length)
-        _check_kwarg_units_helper(kwargs, "example_cutoff", dimensions.length, list_length=2)
+        _check_kwarg_units_helper(
+            kwargs, "example_cutoff", dimensions.length, list_length=2
+        )
         with pytest.raises(TypeError, match=""):
-            _check_kwarg_units_helper(kwargs, "example_cutoff", dimensions.pressure)
-        _check_kwarg_units_helper(kwargs, "example_cutoff_list", dimensions.length, list_length=2)
+            _check_kwarg_units_helper(
+                kwargs, "example_cutoff", dimensions.pressure
+            )
+        _check_kwarg_units_helper(
+            kwargs, "example_cutoff_list", dimensions.length, list_length=2
+        )
         with pytest.raises(TypeError, match=""):
-            _check_kwarg_units_helper(kwargs, "example_cutoff_list", dimensions.pressure, list_length=2)
+            _check_kwarg_units_helper(
+                kwargs,
+                "example_cutoff_list",
+                dimensions.pressure,
+                list_length=2,
+            )
         with pytest.raises(TypeError, match=""):
-            _check_kwarg_units_helper(kwargs, "example_cutoff_list", dimensions.length, list_length=3)
+            _check_kwarg_units_helper(
+                kwargs, "example_cutoff_list", dimensions.length, list_length=3
+            )
         with pytest.raises(TypeError, match=""):
-            _check_kwarg_units_helper(kwargs, "example_cutoff_list", dimensions.length)
-
+            _check_kwarg_units_helper(
+                kwargs, "example_cutoff_list", dimensions.length
+            )
 
     def test_convert_kwarg_units_helper(self):
         kwargs = {
-            "example_cutoff" : 5.5 * u.angstrom,
-            "example_cutoff_list" : [5.5 * u.angstrom, 6.0 * u.angstrom],
-            "example_cutoff_array" : [5.5, 6.0] * u.angstrom,
+            "example_cutoff": 5.5 * u.angstrom,
+            "example_cutoff_list": [5.5 * u.angstrom, 6.0 * u.angstrom],
+            "example_cutoff_array": [5.5, 6.0] * u.angstrom,
         }
         _convert_kwarg_units_helper(kwargs, "example_cutoff", "nm")
         assert kwargs["example_cutoff"].units == u.nm
@@ -42,8 +58,9 @@ class TestKwargUnits(BaseTest):
             _convert_kwarg_units_helper(kwargs, "example_cutoff_list", "nm")
         _convert_kwarg_units_helper(kwargs, "example_cutoff_array", "nm")
         assert kwargs["example_cutoff_array"].units == u.nm
-        assert allclose_units(kwargs["example_cutoff_array"], [0.55, 0.60] * u.nm)
-
+        assert allclose_units(
+            kwargs["example_cutoff_array"], [0.55, 0.60] * u.nm
+        )
 
     def test_validate_unit_list(self):
         list_ = [3.0 * u.angstrom, 1.0 * u.angstrom, 1.5 * u.angstrom]

--- a/mosdef_cassandra/tests/test_kwarg_units.py
+++ b/mosdef_cassandra/tests/test_kwarg_units.py
@@ -1,0 +1,51 @@
+import pytest
+import unyt as u
+import mosdef_cassandra as mc
+
+from unyt import dimensions
+from unyt.array import allclose_units
+from mosdef_cassandra.tests.base_test import BaseTest
+from mosdef_cassandra.writers.inp_functions import _check_kwarg_units_helper, _convert_kwarg_units_helper
+from mosdef_cassandra.utils.units import validate_unit_list
+
+
+class TestKwargUnits(BaseTest):
+
+    def test_check_kwarg_units_helper(self):
+        kwargs = {
+            "example_cutoff" : 5.5 * u.angstrom,
+            "example_cutoff_list" : [5.5 * u.angstrom, 6.0 * u.angstrom]
+        }
+        _check_kwarg_units_helper(kwargs, "example_cutoff", dimensions.length)
+        _check_kwarg_units_helper(kwargs, "example_cutoff", dimensions.length, list_length=2)
+        with pytest.raises(TypeError, match=""):
+            _check_kwarg_units_helper(kwargs, "example_cutoff", dimensions.pressure)
+        _check_kwarg_units_helper(kwargs, "example_cutoff_list", dimensions.length, list_length=2)
+        with pytest.raises(TypeError, match=""):
+            _check_kwarg_units_helper(kwargs, "example_cutoff_list", dimensions.pressure, list_length=2)
+        with pytest.raises(TypeError, match=""):
+            _check_kwarg_units_helper(kwargs, "example_cutoff_list", dimensions.length, list_length=3)
+        with pytest.raises(TypeError, match=""):
+            _check_kwarg_units_helper(kwargs, "example_cutoff_list", dimensions.length)
+
+
+    def test_convert_kwarg_units_helper(self):
+        kwargs = {
+            "example_cutoff" : 5.5 * u.angstrom,
+            "example_cutoff_list" : [5.5 * u.angstrom, 6.0 * u.angstrom],
+            "example_cutoff_array" : [5.5, 6.0] * u.angstrom,
+        }
+        _convert_kwarg_units_helper(kwargs, "example_cutoff", "nm")
+        assert kwargs["example_cutoff"].units == u.nm
+        assert allclose_units(kwargs["example_cutoff"], 0.55 * u.nm)
+        with pytest.raises(TypeError, match="went wrong"):
+            _convert_kwarg_units_helper(kwargs, "example_cutoff_list", "nm")
+        _convert_kwarg_units_helper(kwargs, "example_cutoff_array", "nm")
+        assert kwargs["example_cutoff_array"].units == u.nm
+        assert allclose_units(kwargs["example_cutoff_array"], [0.55, 0.60] * u.nm)
+
+
+    def test_validate_unit_list(self):
+        list_ = [3.0 * u.angstrom, 1.0 * u.angstrom, 1.5 * u.angstrom]
+        with pytest.raises(TypeError):
+            validate_unit_list(list_, (2,), dimensions.length)

--- a/mosdef_cassandra/tests/test_moveset.py
+++ b/mosdef_cassandra/tests/test_moveset.py
@@ -6,6 +6,7 @@ import mosdef_cassandra as mc
 from mosdef_cassandra.tests.base_test import BaseTest
 from unyt.exceptions import IterableUnitCoercionError
 
+
 class TestMoveSet(BaseTest):
     def test_invalid_ensemble(self, methane_oplsaa):
         with pytest.raises(ValueError, match=r"Invalid ensemble"):
@@ -477,8 +478,8 @@ class TestMoveSet(BaseTest):
         moveset = mc.MoveSet("gemc_npt", [methane_oplsaa])
         moveset.max_volume = 1.0 * (u.angstrom ** 3)
         assert len(moveset.max_volume) == 2
-        assert moveset.max_volume[0] == 1.0 * u.angstrom**3
-        assert moveset.max_volume[1] == 1.0 * u.angstrom**3
+        assert moveset.max_volume[0] == 1.0 * u.angstrom ** 3
+        assert moveset.max_volume[1] == 1.0 * u.angstrom ** 3
         with pytest.raises(TypeError, match=r"must be a list"):
             moveset.max_volume = [
                 1.0 * (u.angstrom ** 3),

--- a/mosdef_cassandra/tests/test_moveset.py
+++ b/mosdef_cassandra/tests/test_moveset.py
@@ -542,22 +542,22 @@ class TestMoveSet(BaseTest):
             moveset.cbmc_n_dihed = -2
         moveset.cbmc_n_dihed = 20
         assert moveset.cbmc_n_dihed == 20
-        with pytest.raises(TypeError, match=r"of type float"):
-            moveset.cbmc_rcut = [3.0, [3.0]]
+        with pytest.raises(TypeError, match=r"a unyt_array"):
+            moveset.cbmc_rcut = [3.0 * u.angstrom, [3.0 * u.angstrom]]
         with pytest.raises(ValueError, match=r"less than zero"):
-            moveset.cbmc_rcut = [3.0, -3.0]
-        moveset.cbmc_rcut = [4.0, 8.0]
+            moveset.cbmc_rcut = [3.0 * u.angstrom, -3.0 * u.angstrom]
+        moveset.cbmc_rcut = [0.4 * u.nm, 8.0 * u.angstrom]
         assert len(moveset.cbmc_rcut) == 2
-        assert moveset.cbmc_rcut[0] == 4.0
-        assert moveset.cbmc_rcut[1] == 8.0
-        moveset.cbmc_rcut = 5.0
+        assert moveset.cbmc_rcut[0].to_value("angstrom") == 4.0
+        assert moveset.cbmc_rcut[1].to_value("angstrom") == 8.0
+        moveset.cbmc_rcut = 5.0 * u.angstrom
         assert len(moveset.cbmc_rcut) == 2
-        assert moveset.cbmc_rcut[0] == 5.0
-        assert moveset.cbmc_rcut[1] == 5.0
+        assert moveset.cbmc_rcut[0].to_value("angstrom") == 5.0
+        assert moveset.cbmc_rcut[1].to_value("angstrom") == 5.0
         moveset = mc.MoveSet("nvt", [methane_oplsaa])
-        moveset.cbmc_rcut = 7.0
+        moveset.cbmc_rcut = 7.0 * u.angstrom
         assert len(moveset.cbmc_rcut) == 1
-        assert moveset.cbmc_rcut[0] == 7.0
+        assert moveset.cbmc_rcut[0].to_value("angstrom") == 7.0
 
     def test_print_moveset(self, methane_oplsaa):
         """Simple test to make sure moveset object is printed"""

--- a/mosdef_cassandra/tests/test_moveset.py
+++ b/mosdef_cassandra/tests/test_moveset.py
@@ -1,10 +1,10 @@
 import pytest
-
-import mosdef_cassandra as mc
-import unyt as u
 import warnings
-from mosdef_cassandra.tests.base_test import BaseTest
+import unyt as u
+import mosdef_cassandra as mc
 
+from mosdef_cassandra.tests.base_test import BaseTest
+from unyt.exceptions import IterableUnitCoercionError
 
 class TestMoveSet(BaseTest):
     def test_invalid_ensemble(self, methane_oplsaa):
@@ -331,42 +331,42 @@ class TestMoveSet(BaseTest):
             moveset.prob_translate = []
         with pytest.raises(TypeError, match=r"prob_translate must"):
             moveset.prob_translate = True
-        with pytest.raises(ValueError, match=r"Probability must"):
+        with pytest.raises(ValueError, match=r"be between 0.0 and 1.0"):
             moveset.prob_translate = -0.2
 
         with pytest.raises(TypeError, match=r"prob_rotate must"):
             moveset.prob_rotate = []
         with pytest.raises(TypeError, match=r"prob_rotate must"):
             moveset.prob_rotate = True
-        with pytest.raises(ValueError, match=r"Probability must"):
+        with pytest.raises(ValueError, match=r"be between 0.0 and 1.0"):
             moveset.prob_rotate = -0.2
 
         with pytest.raises(TypeError, match=r"prob_angle must"):
             moveset.prob_angle = []
         with pytest.raises(TypeError, match=r"prob_angle must"):
             moveset.prob_angle = True
-        with pytest.raises(ValueError, match=r"Probability must"):
+        with pytest.raises(ValueError, match=r"be between 0.0 and 1.0"):
             moveset.prob_angle = -0.2
 
         with pytest.raises(TypeError, match=r"prob_dihedral must"):
             moveset.prob_dihedral = []
         with pytest.raises(TypeError, match=r"prob_dihedral must"):
             moveset.prob_dihedral = True
-        with pytest.raises(ValueError, match=r"Probability must"):
+        with pytest.raises(ValueError, match=r"be between 0.0 and 1.0"):
             moveset.prob_dihedral = -0.2
 
         with pytest.raises(TypeError, match=r"prob_regrow must"):
             moveset.prob_regrow = []
         with pytest.raises(TypeError, match=r"prob_regrow must"):
             moveset.prob_regrow = True
-        with pytest.raises(ValueError, match=r"Probability must"):
+        with pytest.raises(ValueError, match=r"be between 0.0 and 1.0"):
             moveset.prob_regrow = -0.2
 
         with pytest.raises(TypeError, match=r"prob_volume must"):
             moveset.prob_volume = []
         with pytest.raises(TypeError, match=r"prob_volume must"):
             moveset.prob_volume = True
-        with pytest.raises(ValueError, match=r"Probability must"):
+        with pytest.raises(ValueError, match=r"be between 0.0 and 1.0"):
             moveset.prob_volume = -0.2
         with pytest.raises(ValueError, match=r"Ensemble is nvt."):
             moveset.prob_volume = 0.02
@@ -380,7 +380,7 @@ class TestMoveSet(BaseTest):
             moveset.prob_insert = []
         with pytest.raises(TypeError, match=r"prob_insert must"):
             moveset.prob_insert = True
-        with pytest.raises(ValueError, match=r"Probability must"):
+        with pytest.raises(ValueError, match=r"be between 0.0 and 1.0"):
             moveset.prob_insert = -0.2
         with pytest.raises(ValueError, match=r"Ensemble is nvt."):
             moveset.prob_insert = 0.2
@@ -393,7 +393,7 @@ class TestMoveSet(BaseTest):
             moveset.prob_swap = []
         with pytest.raises(TypeError, match=r"prob_swap must"):
             moveset.prob_swap = True
-        with pytest.raises(ValueError, match=r"Probability must"):
+        with pytest.raises(ValueError, match=r"be between 0.0 and 1.0"):
             moveset.prob_swap = -0.2
         with pytest.raises(ValueError, match=r"Ensemble is nvt."):
             moveset.prob_swap = 0.2
@@ -403,9 +403,9 @@ class TestMoveSet(BaseTest):
 
     def test_maxval_setters(self, methane_oplsaa):
         moveset = mc.MoveSet("gemc", [methane_oplsaa])
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.max_translate = 1.0 * u.angstrom
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.max_translate = [
                 [1.0 * u.angstrom, 1.0 * u.angstrom],
                 [1.0 * u.angstrom],
@@ -417,52 +417,52 @@ class TestMoveSet(BaseTest):
         moveset.max_translate = [[1.0 * u.angstrom], [1 * u.angstrom]]
         assert moveset.max_translate[1][0] == 1.0 * u.angstrom
 
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.max_rotate = 1.0 * u.degree
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.max_rotate = [
                 [1.0 * u.degree, 1.0 * u.degree],
                 [1.0 * u.degree],
             ]
         with pytest.raises(TypeError, match=r"unyt_array"):
             moveset.max_rotate = [[1.0], [True]]
-        with pytest.raises(ValueError, match=r"cannot be less than zero"):
+        with pytest.raises(ValueError, match=r"must be between"):
             moveset.max_rotate = [[1.0 * u.degree], [-1.0 * u.degree]]
         moveset.max_rotate = [[1.0 * u.degree], [1 * u.degree]]
         assert moveset.max_rotate[1][0] == 1.0 * u.degree
 
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.max_dihedral = 1.0 * u.degree
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.max_dihedral = [
                 1.0 * u.degree,
                 1.0 * u.degree,
                 1.0 * u.degree,
             ]
-        with pytest.raises(TypeError, match=r"unyt array"):
+        with pytest.raises(TypeError, match=r"unyt_array"):
             moveset.max_dihedral = [True]
-        with pytest.raises(ValueError, match=r"cannot be less than zero"):
+        with pytest.raises(ValueError, match=r"must be between"):
             moveset.max_dihedral = [-1.0 * u.degree]
-        with pytest.raises(ValueError, match=r"greater than 360"):
+        with pytest.raises(ValueError, match=r"must be between"):
             moveset.max_dihedral = [370.0 * u.degree]
         moveset.max_dihedral = [1.0 * u.degree]
         assert moveset.max_dihedral[0] == 1.0 * u.degree
 
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.prob_swap_from_box = 1.0
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.prob_swap_from_box = [1.0, 1.0, 1.0]
         with pytest.raises(TypeError, match=r"of type float"):
             moveset.prob_swap_from_box = [0.5, True]
-        with pytest.raises(ValueError, match=r"cannot be less than zero"):
+        with pytest.raises(ValueError, match=r"must be between"):
             moveset.prob_swap_from_box = [0.5, -0.5]
         moveset.prob_swap_from_box = [0.5, 0.5]
         assert moveset.prob_swap_from_box[0] == 0.5
 
         moveset = mc.MoveSet("gemc", [methane_oplsaa])
-        with pytest.raises(TypeError, match=r"list with length"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.max_volume = 1.0
-        with pytest.raises(TypeError, match=r"list with length"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.max_volume = [
                 1.0 * (u.angstrom ** 3),
                 1.0 * (u.angstrom ** 3),
@@ -475,9 +475,11 @@ class TestMoveSet(BaseTest):
         moveset.max_volume = [5000.0 * (u.angstrom ** 3)]
         assert moveset.max_volume[0] == 5000.0 * (u.angstrom ** 3)
         moveset = mc.MoveSet("gemc_npt", [methane_oplsaa])
-        with pytest.raises(TypeError, match=r"list with length"):
-            moveset.max_volume = 1.0 * (u.angstrom ** 3)
-        with pytest.raises(TypeError, match=r"list with length"):
+        moveset.max_volume = 1.0 * (u.angstrom ** 3)
+        assert len(moveset.max_volume) == 2
+        assert moveset.max_volume[0] == 1.0 * u.angstrom**3
+        assert moveset.max_volume[1] == 1.0 * u.angstrom**3
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.max_volume = [
                 1.0 * (u.angstrom ** 3),
                 1.0 * (u.angstrom ** 3),
@@ -497,33 +499,33 @@ class TestMoveSet(BaseTest):
         assert moveset.max_volume[1] == 50000.0 * (u.angstrom ** 3)
 
         moveset = mc.MoveSet("gemc", [methane_oplsaa])
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.insertable = 1.0
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.insertable = [1.0, 1.0, 1.0]
         with pytest.raises(TypeError, match=r"as a boolean type"):
             moveset.insertable = [2.0]
         moveset.insertable = [True]
         assert moveset.insertable[0] == True
 
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.prob_swap_species = 1.0
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.prob_swap_species = [1.0, 1.0, 1.0]
         with pytest.raises(TypeError, match=r"of type float"):
             moveset.prob_swap_species = [True]
-        with pytest.raises(ValueError, match=r"cannot be less than zero"):
+        with pytest.raises(ValueError, match=r"must be between"):
             moveset.prob_swap_species = [-1.0]
         moveset.prob_swap_species = [1.0]
         assert moveset.prob_swap_species[0] == 1.0
 
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.prob_regrow_species = 1.0
-        with pytest.raises(ValueError, match=r"must be a list"):
+        with pytest.raises(TypeError, match=r"must be a list"):
             moveset.prob_regrow_species = [1.0, 1.0, 1.0]
         with pytest.raises(TypeError, match=r"of type float"):
             moveset.prob_regrow_species = [True]
-        with pytest.raises(ValueError, match=r"cannot be less than zero"):
+        with pytest.raises(ValueError, match=r"must be between"):
             moveset.prob_regrow_species = [-1.0]
         moveset.prob_regrow_species = [1.0]
         assert moveset.prob_regrow_species[0] == 1.0
@@ -542,14 +544,14 @@ class TestMoveSet(BaseTest):
             moveset.cbmc_n_dihed = -2
         moveset.cbmc_n_dihed = 20
         assert moveset.cbmc_n_dihed == 20
-        with pytest.raises(TypeError, match=r"a unyt_array"):
-            moveset.cbmc_rcut = [3.0 * u.angstrom, [3.0 * u.angstrom]]
+        with pytest.raises(TypeError, match=r"unyt_array"):
+            moveset.cbmc_rcut = [3.0 * u.angstrom]
+        with pytest.raises(TypeError, match=r"unyt_array"):
+            moveset.cbmc_rcut = 3.0
         with pytest.raises(ValueError, match=r"less than zero"):
             moveset.cbmc_rcut = [3.0 * u.angstrom, -3.0 * u.angstrom]
-        moveset.cbmc_rcut = [0.4 * u.nm, 8.0 * u.angstrom]
-        assert len(moveset.cbmc_rcut) == 2
-        assert moveset.cbmc_rcut[0].to_value("angstrom") == 4.0
-        assert moveset.cbmc_rcut[1].to_value("angstrom") == 8.0
+        with pytest.raises(IterableUnitCoercionError):
+            moveset.cbmc_rcut = [0.4 * u.nm, 8.0 * u.angstrom]
         moveset.cbmc_rcut = 5.0 * u.angstrom
         assert len(moveset.cbmc_rcut) == 2
         assert moveset.cbmc_rcut[0].to_value("angstrom") == 5.0

--- a/mosdef_cassandra/tests/test_utils.py
+++ b/mosdef_cassandra/tests/test_utils.py
@@ -95,7 +95,9 @@ class TestConvertBox(BaseTest):
 
     def test_unit_err_msg(self):
         with pytest.raises(TypeError, match="test must be a"):
-            validate_unit(1 * u.nm, dimensions.temperature, argument_name="test")
+            validate_unit(
+                1 * u.nm, dimensions.temperature, argument_name="test"
+            )
 
     @pytest.mark.parametrize(
         "unit_list, shape, dimension",
@@ -139,8 +141,15 @@ class TestConvertBox(BaseTest):
         "unit_list, shape, dimension",
         [
             ([[1.0 * u.angstrom, 1.0 * u.nm]], (2, 1), dimensions.length),
-            ([[1.0 * u.nm, 1.0 * u.nm], [1.0 * u.angstrom, 1.0 * u.angstrom]], (2, 2), dimensions.length),
-        ]
+            (
+                [
+                    [1.0 * u.nm, 1.0 * u.nm],
+                    [1.0 * u.angstrom, 1.0 * u.angstrom],
+                ],
+                (2, 2),
+                dimensions.length,
+            ),
+        ],
     )
     def test_mismatch_unit_list(self, unit_list, shape, dimension):
         with pytest.raises(IterableUnitCoercionError):

--- a/mosdef_cassandra/tests/test_writers.py
+++ b/mosdef_cassandra/tests/test_writers.py
@@ -552,7 +552,7 @@ class TestInpFunctions(BaseTest):
         )
 
         assert (
-            "# Molecule_Files\nspecies1.mcf 1\nspecies2.mcf 510\n" in inp_data
+            "# Molecule_Files\nspecies1.mcf 1\nspecies2.mcf 2010\n" in inp_data
         )
 
         (system, moveset) = twocomp_system
@@ -1509,7 +1509,7 @@ class TestInpFunctions(BaseTest):
         )
 
         (system, moveset) = onecomp_system
-        moveset.cbmc_rcut = [4.5]
+        moveset.cbmc_rcut = [0.45 * u.nm]
         moveset.cbmc_n_insert = 2
         moveset.cbmc_n_dihed = 5
         inp_data = generate_input(
@@ -1518,9 +1518,6 @@ class TestInpFunctions(BaseTest):
             run_type="equilibration",
             run_length=500,
             temperature=300.0 * u.K,
-            cbmc_kappa_ins=2,
-            cbmc_kappa_dih=5,
-            cbmc_rcut=4.5 * u.angstrom,
         )
         print(inp_data)
 
@@ -1528,42 +1525,6 @@ class TestInpFunctions(BaseTest):
             "# CBMC_Info\nkappa_ins 2\nkappa_dih 5\nrcut_cbmc 4.5\n"
             in inp_data
         )
-
-        with pytest.raises(TypeError, match=r"must be an integer"):
-            inp_data = generate_input(
-                system=system,
-                moveset=moveset,
-                run_type="equilibration",
-                run_length=500,
-                temperature=300.0 * u.K,
-                cbmc_kappa_ins=2.5,
-                cbmc_kappa_dih=5,
-                cbmc_rcut=4.5 * u.angstrom,
-            )
-
-        with pytest.raises(TypeError, match=r"must be an integer"):
-            inp_data = generate_input(
-                system=system,
-                moveset=moveset,
-                run_type="equilibration",
-                run_length=500,
-                temperature=300.0 * u.K,
-                cbmc_kappa_ins=2,
-                cbmc_kappa_dih=5.5,
-                cbmc_rcut=4.5 * u.angstrom,
-            )
-
-        with pytest.raises(TypeError, match=r"must be a unyt_array"):
-            inp_data = generate_input(
-                system=system,
-                moveset=moveset,
-                run_type="equilibration",
-                run_length=500,
-                temperature=300.0 * u.K,
-                cbmc_kappa_ins=2,
-                cbmc_kappa_dih=5,
-                cbmc_rcut=[],
-            )
 
     @pytest.mark.parametrize(
         "typ,value",

--- a/mosdef_cassandra/utils/units.py
+++ b/mosdef_cassandra/utils/units.py
@@ -42,7 +42,7 @@ def validate_unit_list(
             f"of {valid_dimension}"
         )
 
-    if type(list_) == list:
+    if type(list_) in (list, tuple):
         new_list = []
         for item in list_:
             try:

--- a/mosdef_cassandra/utils/units.py
+++ b/mosdef_cassandra/utils/units.py
@@ -2,14 +2,39 @@ import unyt as u
 from unyt import accepts
 
 
-def validate_unit(unyt_array, dimension):
+def validate_unit(unyt_array, valid_dimension, argument_name):
     if isinstance(unyt_array, u.unyt_array):
 
-        @accepts(unyt_array=dimension)
+        @accepts(unyt_array=valid_dimension)
         def _validate(unyt_array):
             return unyt_array
 
     else:
-        raise TypeError("Argument must be a unyt_array")
+        raise TypeError(f"{argument_name} must be a unyt_array")
 
-    return _validate(unyt_array)
+    try:
+        return _validate(unyt_array)
+    except TypeError:
+        raise TypeError(
+            f"{argument_name} must be a list of unyt_quantities or "
+            f"unyt_array with dimensions of {valid_dimension}"
+        )
+
+
+def validate_unit_list(list_, valid_shape, valid_dimension, argument_name):
+    try:
+        unyt_array = u.unyt_array(list_)
+    except AttributeError:
+        raise TypeError(
+            f"{argument_name} must be a list of unyt_quantities or "
+            f"unyt_array with shape = {valid_shape} and dimensions "
+            f"of {valid_dimension}"
+        )
+    if unyt_array.shape != valid_shape:
+        raise TypeError(
+            f"{argument_name} must be a list of unyt_quantities or "
+            f"unyt_array with shape = {valid_shape} and dimensions "
+            f"of {valid_dimension}"
+        )
+
+    return validate_unit(unyt_array, valid_dimension, argument_name)

--- a/mosdef_cassandra/utils/units.py
+++ b/mosdef_cassandra/utils/units.py
@@ -2,7 +2,18 @@ import unyt as u
 from unyt import accepts
 
 
-def validate_unit(unyt_array, valid_dimension, argument_name):
+def validate_unit(
+    unyt_array, valid_dimension, argument_name=None, err_msg=None
+):
+
+    if argument_name is None:
+        argument_name = "argument"
+    if err_msg is None:
+        err_msg = (
+            f"{argument_name} must be a unyt_quantity or unyt_array "
+            f"with dimensions of {valid_dimension}"
+        )
+
     if isinstance(unyt_array, u.unyt_array):
 
         @accepts(unyt_array=valid_dimension)
@@ -10,31 +21,45 @@ def validate_unit(unyt_array, valid_dimension, argument_name):
             return unyt_array
 
     else:
-        raise TypeError(f"{argument_name} must be a unyt_array")
+        raise TypeError(err_msg)
 
     try:
         return _validate(unyt_array)
     except TypeError:
-        raise TypeError(
+        raise TypeError(err_msg)
+
+
+def validate_unit_list(
+    list_, valid_shape, valid_dimension, argument_name=None, err_msg=None
+):
+
+    if argument_name is None:
+        argument_name = "argument"
+    if err_msg is None:
+        err_msg = (
             f"{argument_name} must be a list of unyt_quantities or "
-            f"unyt_array with dimensions of {valid_dimension}"
+            f"unyt_array with shape = {valid_shape} and dimensions "
+            f"of {valid_dimension}"
         )
 
-
-def validate_unit_list(list_, valid_shape, valid_dimension, argument_name):
+    if type(list_) == list:
+        new_list = []
+        for item in list_:
+            try:
+                shape = (len(item),)
+            except TypeError:
+                shape = ()
+            new_list.append(
+                validate_unit_list(
+                    item, shape, valid_dimension, argument_name, err_msg
+                )
+            )
+        list_ = new_list
     try:
         unyt_array = u.unyt_array(list_)
     except AttributeError:
-        raise TypeError(
-            f"{argument_name} must be a list of unyt_quantities or "
-            f"unyt_array with shape = {valid_shape} and dimensions "
-            f"of {valid_dimension}"
-        )
+        raise TypeError(err_msg)
     if unyt_array.shape != valid_shape:
-        raise TypeError(
-            f"{argument_name} must be a list of unyt_quantities or "
-            f"unyt_array with shape = {valid_shape} and dimensions "
-            f"of {valid_dimension}"
-        )
+        raise TypeError(err_msg)
 
-    return validate_unit(unyt_array, valid_dimension, argument_name)
+    return validate_unit(unyt_array, valid_dimension, argument_name, err_msg)

--- a/mosdef_cassandra/writers/inp_functions.py
+++ b/mosdef_cassandra/writers/inp_functions.py
@@ -270,7 +270,7 @@ def generate_input(
 
         box_matrix = convert_box.convert_to_boxmatrix(box_dims)
         box_matrix = u.unyt_array(box_matrix, "nm")
-        #box_matrix = [u.unyt_array(i, "nm") for i in box_matrix]
+        # box_matrix = [u.unyt_array(i, "nm") for i in box_matrix]
         boxes.append(box_matrix)
     inp_data += get_box_info(
         boxes, moveset._restricted_type, moveset._restricted_value
@@ -343,10 +343,7 @@ def generate_input(
     if moveset.prob_dihedral > 0.0:
         move_prob_dict["dihedral"] = [
             moveset.prob_dihedral,
-            *[
-                [val.to_value() for val in box]
-                for box in moveset.max_dihedral
-            ],
+            *[[val.to_value() for val in box] for box in moveset.max_dihedral],
         ]
     if moveset.prob_regrow > 0.0:
         move_prob_dict["regrow"] = [
@@ -874,10 +871,10 @@ def get_box_info(boxes, restricted_type, restricted_value):
     for box in boxes:
         # unyt array doesn't seem to support 3D arrays right now
         # so the shape has to be checked in a more roundabout way
-        assert box.shape == (3,3)
+        assert box.shape == (3, 3)
         box.convert_to_units("angstrom")
-        #assert len(box) == 3
-        #for dims in box:
+        # assert len(box) == 3
+        # for dims in box:
         #    assert dims.shape == (3,)
         #    dims.convert_to_units("angstrom")
 
@@ -889,7 +886,12 @@ def get_box_info(boxes, restricted_type, restricted_value):
 
     box_types = []
     for box in boxes:
-        if np.count_nonzero(box.to_value() - np.diag(np.diagonal(box.to_value()))) == 0:
+        if (
+            np.count_nonzero(
+                box.to_value() - np.diag(np.diagonal(box.to_value()))
+            )
+            == 0
+        ):
             if np.all(np.diagonal(box.to_value()) == box[0][0].to_value()):
                 box_types.append("cubic")
             else:
@@ -1966,12 +1968,13 @@ def _check_kwarg_units(kwargs):
     _check_kwarg_units_helper(kwargs, "pressure", dimensions.pressure)
     _check_kwarg_units_helper(kwargs, "pressure_box1", dimensions.pressure)
     _check_kwarg_units_helper(kwargs, "pressure_box2", dimensions.pressure)
-    
+
     # Handle chemical potentials here because quirky
     if "chemical_potentials" in kwargs:
         for mu in kwargs["chemical_potentials"]:
             if not isinstance(mu, str):
                 validate_unit(mu, dimensions.energy)
+
 
 def _check_kwarg_units_helper(kwargs, kwarg_name, dimension, list_length=0):
     if kwarg_name not in kwargs:
@@ -1981,22 +1984,17 @@ def _check_kwarg_units_helper(kwargs, kwarg_name, dimension, list_length=0):
         # Make sure length is *actually* 1
         if type(kwargs[kwarg_name]) == u.unyt_array:
             if kwargs[kwarg_name].size > 1:
-                raise TypeError(
-                    f"Invalid format for argument {kwarg_name}"
-                )
+                raise TypeError(f"Invalid format for argument {kwarg_name}")
     else:
         # Logic checks if we have an array/list vs. single item array/quantity
         if (
-            isinstance(kwargs[kwarg_name], (u.unyt_quantity)) or
-            len(kwargs[kwarg_name]) == 1
+            isinstance(kwargs[kwarg_name], (u.unyt_quantity))
+            or len(kwargs[kwarg_name]) == 1
         ):
             validate_unit(kwargs[kwarg_name], dimension)
         else:
             kwargs[kwarg_name] = validate_unit_list(
-                kwargs[kwarg_name],
-                (list_length,),
-                dimension,
-                kwarg_name,
+                kwargs[kwarg_name], (list_length,), dimension, kwarg_name,
             )
 
 

--- a/mosdef_cassandra/writers/inp_functions.py
+++ b/mosdef_cassandra/writers/inp_functions.py
@@ -393,7 +393,7 @@ def generate_input(
     inp_data += get_cbmc_info(
         moveset.cbmc_n_insert,
         moveset.cbmc_n_dihed,
-        [i.to_value() for i in moveset.cbmc_rcut]
+        [i.to_value() for i in moveset.cbmc_rcut],
     )
 
     # Start type info


### PR DESCRIPTION
This PR was originally limited to replacing `kwargs` CBMC parameters with `MoveSet` CBMC parameters, but has since grown to include other fixes/nits and (hopefully) more robust checking on the `unyt_arrays` in particular.

See commit messages for a more complete description of all the changes.

Tests are passing but I still want to check coverage and go examine with a closer inspection prior to merging.