### PR TITLE
Add back in methane nvt example and Update Docs

### DIFF
--- a/docs/source/getting_started/examples.rst
+++ b/docs/source/getting_started/examples.rst
@@ -8,7 +8,7 @@ MoSDeF Cassandra.
 NVT simulation of methane
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. literalinclude:: ../../../mosdef_cassandra/examples/nvt.py
+.. literalinclude:: ../../../mosdef_cassandra/examples/nvt_methane.py
   :language: python
 
 NPT simulation of methane
@@ -21,6 +21,12 @@ NVT simulation of methane and propane mixture
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. literalinclude:: ../../../mosdef_cassandra/examples/nvt_mixture.py
+  :language: python
+
+NVT simulation of SPC/E water
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. literalinclude:: ../../../mosdef_cassandra/examples/nvt_water.py
   :language: python
 
 GEMC simulation of methane

--- a/mosdef_cassandra/examples/__init__.py
+++ b/mosdef_cassandra/examples/__init__.py
@@ -1,4 +1,5 @@
-from .nvt import run_nvt
+from .nvt_water import run_water_nvt
+from .nvt_methane import run_methane_nvt
 from .npt import run_npt
 from .gcmc import run_gcmc
 from .gemc import run_gemc

--- a/mosdef_cassandra/examples/nvt_methane.py
+++ b/mosdef_cassandra/examples/nvt_methane.py
@@ -1,27 +1,26 @@
 import mbuild
 import foyer
-import numpy as np
 import mosdef_cassandra as mc
 import unyt as u
-from scipy.spatial.transform import Rotation
-from mosdef_cassandra.utils.get_files import get_ff_path, get_mol2_path
 
 
-def run_nvt(custom_args={}):
-    molecule = mbuild.load(get_mol2_path("spce"))
+def run_methane_nvt(custom_args={}):
+
+    # Use mbuild to create molecules
+    methane = mbuild.load("C", smiles=True)
 
     # Create an empty mbuild.Box
     box = mbuild.Box(lengths=[3.0, 3.0, 3.0])
 
     # Load forcefields
-    spce = foyer.Forcefield(get_ff_path("spce"))
+    oplsaa = foyer.forcefields.load_OPLSAA()
 
     # Use foyer to apply forcefields
-    molecule_ff = spce.apply(molecule)
+    methane_ff = oplsaa.apply(methane)
 
     # Create box and species list
     box_list = [box]
-    species_list = [molecule_ff]
+    species_list = [methane_ff]
 
     # Use Cassandra to insert some initial number of species
     mols_to_add = [[50]]
@@ -43,4 +42,4 @@ def run_nvt(custom_args={}):
 
 
 if __name__ == "__main__":
-    run_nvt()
+    run_methane_nvt()

--- a/mosdef_cassandra/examples/nvt_water.py
+++ b/mosdef_cassandra/examples/nvt_water.py
@@ -1,0 +1,46 @@
+import mbuild
+import foyer
+import numpy as np
+import mosdef_cassandra as mc
+import unyt as u
+from scipy.spatial.transform import Rotation
+from mosdef_cassandra.utils.get_files import get_ff_path, get_mol2_path
+
+
+def run_water_nvt(custom_args={}):
+    molecule = mbuild.load(get_mol2_path("spce"))
+
+    # Create an empty mbuild.Box
+    box = mbuild.Box(lengths=[3.0, 3.0, 3.0])
+
+    # Load forcefields
+    spce = foyer.Forcefield(get_ff_path("spce"))
+
+    # Use foyer to apply forcefields
+    molecule_ff = spce.apply(molecule)
+
+    # Create box and species list
+    box_list = [box]
+    species_list = [molecule_ff]
+
+    # Use Cassandra to insert some initial number of species
+    mols_to_add = [[50]]
+
+    # Define the system object
+    system = mc.System(box_list, species_list, mols_to_add=mols_to_add)
+    # Get the move probabilities
+    moveset = mc.MoveSet("nvt", species_list)
+
+    # Run a simulation with at 300 K with 10000 MC moveset
+    mc.run(
+        system=system,
+        moveset=moveset,
+        run_type="equilibration",
+        run_length=10000,
+        temperature=300.0 * u.K,
+        **custom_args,
+    )
+
+
+if __name__ == "__main__":
+    run_water_nvt()

--- a/mosdef_cassandra/tests/test_examples.py
+++ b/mosdef_cassandra/tests/test_examples.py
@@ -12,10 +12,33 @@ from mosdef_cassandra.tests.base_test import BaseTest
 
 class TestExamples(BaseTest):
     @pytest.mark.parametrize("custom_args", [{"angle_style": ["fixed"]}, {}])
-    def test_run_nvt(self, custom_args):
+    def test_run_water_nvt(self, custom_args):
         with temporary_directory() as tmp_dir:
             with temporary_cd(tmp_dir):
-                ex.run_nvt(custom_args=custom_args)
+                ex.run_water_nvt(custom_args=custom_args)
+                log_files = sorted(
+                    glob.glob("./mosdef_cassandra*.log"), key=os.path.getmtime
+                )
+                log_file = log_files[-1]
+                log_data = []
+                save_data = False
+                with open(log_file) as log:
+                    for line in log:
+                        if "CASSANDRA STANDARD" in line:
+                            save_data = True
+                        if save_data == True:
+                            log_data.append(line)
+
+                completed = False
+                for line in log_data:
+                    if "Cassandra simulation complete" in line:
+                        completed = True
+                assert completed
+
+    def test_run_methane_nvt(self):
+        with temporary_directory() as tmp_dir:
+            with temporary_cd(tmp_dir):
+                ex.run_methane_nvt()
                 log_files = sorted(
                     glob.glob("./mosdef_cassandra*.log"), key=os.path.getmtime
                 )
@@ -42,7 +65,7 @@ class TestExamples(BaseTest):
                 with pytest.raises(
                     CassandraRuntimeError, match=r"Cassandra exited with"
                 ):
-                    ex.run_nvt(custom_args=kwargs)
+                    ex.run_methane_nvt(custom_args=kwargs)
 
     def test_run_npt(self):
         with temporary_directory() as tmp_dir:


### PR DESCRIPTION
This addresss #78 by adding back in the methane nvt example.  The docs have been updated so that the methane and water nvt examples are included and correctly labeled.  Tests have subsequently been updated as well.