### PR TITLE
Remove spacing after each custom nb definintion in input file

### DIFF
--- a/mosdef_cassandra/tests/test_examples.py
+++ b/mosdef_cassandra/tests/test_examples.py
@@ -32,6 +32,33 @@ class TestExamples(BaseTest):
                         completed = True
                 assert completed
 
+    def test_run_nvt_custom_mixing(self):
+        mixing_dict = {"opls_138_s1 opls_140_s1": "1.0 1.0"}
+        custom_args = {"mixing_rule": "custom",
+                       "custom_mixing_dict": mixing_dict,
+                      }
+        with temporary_directory() as tmp_dir:
+            with temporary_cd(tmp_dir):
+                ex.run_nvt(**custom_args)
+                log_files = sorted(
+                    glob.glob("./mosdef_cassandra*.log"), key=os.path.getmtime
+                )
+                log_file = log_files[-1]
+                log_data = []
+                save_data = False
+                with open(log_file) as log:
+                    for line in log:
+                        if "CASSANDRA STANDARD" in line:
+                            save_data = True
+                        if save_data:
+                            log_data.append(line)
+
+                completed = False
+                for line in log_data:
+                    if "Cassandra simulation complete" in line:
+                        completed = True
+                assert completed
+
     @pytest.mark.parametrize("custom_args", [{"angle_style": ["fixed"]}, {}])
     def test_run_nvt_spce(self, custom_args):
         with temporary_directory() as tmp_dir:

--- a/mosdef_cassandra/tests/test_examples.py
+++ b/mosdef_cassandra/tests/test_examples.py
@@ -34,9 +34,10 @@ class TestExamples(BaseTest):
 
     def test_run_nvt_custom_mixing(self):
         mixing_dict = {"opls_138_s1 opls_140_s1": "1.0 1.0"}
-        custom_args = {"mixing_rule": "custom",
-                       "custom_mixing_dict": mixing_dict,
-                      }
+        custom_args = {
+            "mixing_rule": "custom",
+            "custom_mixing_dict": mixing_dict,
+        }
         with temporary_directory() as tmp_dir:
             with temporary_cd(tmp_dir):
                 ex.run_nvt(**custom_args)

--- a/mosdef_cassandra/writers/inp_functions.py
+++ b/mosdef_cassandra/writers/inp_functions.py
@@ -761,8 +761,7 @@ def get_mixing_rule(mixing_rule, custom_mixing_dict=None):
 
     if mixing_rule == "custom":
         for pair, parms in custom_mixing_dict.items():
-            inp_data += """
-{pair} {parms}
+            inp_data += """{pair} {parms}
 """.format(
                 pair=pair, parms=parms
             )

--- a/mosdef_cassandra/writers/inp_functions.py
+++ b/mosdef_cassandra/writers/inp_functions.py
@@ -755,7 +755,8 @@ def get_mixing_rule(mixing_rule, custom_mixing_dict=None):
 
     inp_data = """
 # Mixing_Rule
-{mixing_rule}""".format(
+{mixing_rule}
+""".format(
         mixing_rule=mixing_rule
     )
 


### PR DESCRIPTION
There is a small bug that incorrectly formats the custom mixing rules in the input file with blank lines like this:

```
# Mixing_Rule
custom
GPH_s3 mxene_001_s1 0.30663554 4.083

GPH_s3 mxene_002_s1 0.30663554 4.083

GPH_s3 mxene_003_s1 0.30663554 4.083

GPH_s3 mxene_004_s1 0.09316257 4.2766

GPH_s3 mxene_005_s1 0.0 4.083
```

This small fix removes those blank lines so systems with custom mixing rules can be successfully run.