### PR TITLE
Add constrainmol support to meet bond length requirements

### DIFF
--- a/mosdef_cassandra/core/system.py
+++ b/mosdef_cassandra/core/system.py
@@ -8,12 +8,12 @@ import parmed
 
 class System(object):
     def __init__(
-            self,
-            boxes,
-            species_topologies,
-            mols_in_boxes=None,
-            mols_to_add=None,
-            fix_bonds=True,
+        self,
+        boxes,
+        species_topologies,
+        mols_in_boxes=None,
+        mols_to_add=None,
+        fix_bonds=True,
     ):
         """A class to contain the system to simulate in Cassandra
 
@@ -77,7 +77,6 @@ class System(object):
         if fix_bonds:
             self.fix_bonds()
 
-
     # TODO: one possibility is to return list(self._boxes)
     # rather than self._boxes --> this prevents list items from
     # being edited ¯\_(ツ)_/¯
@@ -139,8 +138,9 @@ class System(object):
                 else:
                     self._constrained_species.append(None)
 
-            self._species_topologies = [parmed.structure.copy(s)
-                                        for s in species_topologies]
+            self._species_topologies = [
+                parmed.structure.copy(s) for s in species_topologies
+            ]
         else:
             raise AttributeError(
                 "species_topologies cannot be "
@@ -309,8 +309,7 @@ class System(object):
                     )
 
     def fix_bonds(self):
-        """Apply the bond length constraints to each molecule in the system
-        """
+        """Apply the bond length constraints to each molecule in the system"""
         for ibox, box in enumerate(self.boxes):
             if isinstance(box, mbuild.Box):
                 continue
@@ -327,9 +326,9 @@ class System(object):
                 if constrain is None:
                     start_idx = idx_offset
                     end_idx = idx_offset + n_mols * n_atoms
-                    constrained_coordinates[start_idx:end_idx] = (
-                        unconstrained_coordinates[start_idx:end_idx]
-                    )
+                    constrained_coordinates[
+                        start_idx:end_idx
+                    ] = unconstrained_coordinates[start_idx:end_idx]
                 # Else we apply the constraints one molecule
                 # at a time
                 else:
@@ -340,8 +339,8 @@ class System(object):
                             unconstrained_coordinates[start_idx:end_idx]
                         )
                         constrain.solve()
-                        constrained_coordinates[start_idx:end_idx] = (
-                            constrain.xyz
-                        )
+                        constrained_coordinates[
+                            start_idx:end_idx
+                        ] = constrain.xyz
                 # Now we're done with isp; update idx_offset
                 idx_offset += n_mols * n_atoms

--- a/mosdef_cassandra/core/system.py
+++ b/mosdef_cassandra/core/system.py
@@ -336,12 +336,13 @@ class System(object):
                         start_idx = idx_offset + imol * n_atoms
                         end_idx = idx_offset + (imol + 1) * n_atoms
                         constrain.update_xyz(
-                            unconstrained_coordinates[start_idx:end_idx] * 10.0  # nm to Angstrom
+                            unconstrained_coordinates[start_idx:end_idx]
+                            * 10.0  # nm to Angstrom
                         )
                         constrain.solve()
-                        constrained_coordinates[
-                            start_idx:end_idx
-                        ] = constrain.xyz / 10.0  # Angstrom to nm
+                        constrained_coordinates[start_idx:end_idx] = (
+                            constrain.xyz / 10.0
+                        )  # Angstrom to nm
                 # Now we're done with isp; update idx_offset
                 idx_offset += n_mols * n_atoms
 

--- a/mosdef_cassandra/core/system.py
+++ b/mosdef_cassandra/core/system.py
@@ -336,11 +336,13 @@ class System(object):
                         start_idx = idx_offset + imol * n_atoms
                         end_idx = idx_offset + (imol + 1) * n_atoms
                         constrain.update_xyz(
-                            unconstrained_coordinates[start_idx:end_idx]
+                            unconstrained_coordinates[start_idx:end_idx] * 10.0  # nm to Angstrom
                         )
                         constrain.solve()
                         constrained_coordinates[
                             start_idx:end_idx
-                        ] = constrain.xyz
+                        ] = constrain.xyz / 10.0  # Angstrom to nm
                 # Now we're done with isp; update idx_offset
                 idx_offset += n_mols * n_atoms
+
+            box.xyz = constrained_coordinates

--- a/mosdef_cassandra/core/system.py
+++ b/mosdef_cassandra/core/system.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from constrainmol import ConstrainedMolecule
 
 import numpy as np
 import mbuild
@@ -7,7 +8,12 @@ import parmed
 
 class System(object):
     def __init__(
-        self, boxes, species_topologies, mols_in_boxes=None, mols_to_add=None
+            self,
+            boxes,
+            species_topologies,
+            mols_in_boxes=None,
+            mols_to_add=None,
+            fix_bonds=True,
     ):
         """A class to contain the system to simulate in Cassandra
 
@@ -40,6 +46,10 @@ class System(object):
             one element per box. Each element is a list of length
             n_species, specifying the number of each species that
             should be added to each box
+        fix_bonds : boolean, optional, default=True
+            update the bond lengths in any initial structure
+            (i.e., boxes) to match the values specified in
+            the species_topologies
 
         Returns
         -------
@@ -62,6 +72,11 @@ class System(object):
         # vs. number from self.mols_in_boxes and
         # self.species_topologies
         self.check_natoms()
+
+        # Fix the coordinates if the user provides a starting structure
+        if fix_bonds:
+            self.fix_bonds()
+
 
     # TODO: one possibility is to return list(self._boxes)
     # rather than self._boxes --> this prevents list items from
@@ -102,6 +117,7 @@ class System(object):
 
     @species_topologies.setter
     def species_topologies(self, species_topologies):
+        self._constrained_species = []
         if self._species_topologies is None:
             if not isinstance(species_topologies, list):
                 raise TypeError(
@@ -113,7 +129,18 @@ class System(object):
                     raise TypeError(
                         "Each species should be a " "parmed.Structure"
                     )
-            self._species_topologies = deepcopy(species_topologies)
+                # If no bonds in topology don't try to apply constraints
+                # Store "None" in _constrained_species instead
+                if len(topology.bonds) > 0:
+                    constrain = ConstrainedMolecule(topology)
+                    constrain.solve()
+                    topology.coordinates = constrain.xyz
+                    self._constrained_species.append(constrain)
+                else:
+                    self._constrained_species.append(None)
+
+            self._species_topologies = [parmed.structure.copy(s)
+                                        for s in species_topologies]
         else:
             raise AttributeError(
                 "species_topologies cannot be "
@@ -280,3 +307,41 @@ class System(object):
                             ibox + 1, self.mols_in_boxes[ibox], ibox + 1
                         )
                     )
+
+    def fix_bonds(self):
+        """Apply the bond length constraints to each molecule in the system
+        """
+        for ibox, box in enumerate(self.boxes):
+            if isinstance(box, mbuild.Box):
+                continue
+            unconstrained_coordinates = box.xyz
+            constrained_coordinates = np.zeros(box.xyz.shape)
+            n_species = len(self.species_topologies)
+            idx_offset = 0
+            for isp in range(n_species):
+                constrain = self._constrained_species[isp]
+                n_mols = self.mols_in_boxes[ibox][isp]
+                n_atoms = self._species_topologies[isp].coordinates.shape[0]
+                # If no constrained molecule grab all the coordinates
+                # in one big block
+                if constrain is None:
+                    start_idx = idx_offset
+                    end_idx = idx_offset + n_mols * n_atoms
+                    constrained_coordinates[start_idx:end_idx] = (
+                        unconstrained_coordinates[start_idx:end_idx]
+                    )
+                # Else we apply the constraints one molecule
+                # at a time
+                else:
+                    for imol in range(n_mols):
+                        start_idx = idx_offset + imol * n_atoms
+                        end_idx = idx_offset + (imol + 1) * n_atoms
+                        constrain.update_xyz(
+                            unconstrained_coordinates[start_idx:end_idx]
+                        )
+                        constrain.solve()
+                        constrained_coordinates[start_idx:end_idx] = (
+                            constrain.xyz
+                        )
+                # Now we're done with isp; update idx_offset
+                idx_offset += n_mols * n_atoms

--- a/mosdef_cassandra/examples/__init__.py
+++ b/mosdef_cassandra/examples/__init__.py
@@ -3,7 +3,7 @@ from .npt import run_npt
 from .gcmc import run_gcmc
 from .gemc import run_gemc
 from .nvt_spce import run_nvt_spce
-
 from .nvt_mixture import run_nvt_mixture
+from .nvt_mbuild import run_nvt_mbuild
 from .gcmc_adsorption import run_gcmc_adsorption
 from .gcmc_restricted import run_gcmc_restricted

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ pytest
 cassandra >= 1.2.2
 unyt >= 2.4
 pandas >= 1.0
+constrainmol

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ pytest
 cassandra >= 1.2.2
 unyt >= 2.4
 pandas >= 1.0
+constrainmol

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ networkx
 mbuild >= 0.10.8
 cassandra >= 1.2.2
 unyt >= 2.4
+constrainmol


### PR DESCRIPTION
Cassandra uses fixed bonds. This requires that the initial structure for each type of molecule in the system (and in particular, molecules containing rings) contain bond lengths that _exactly_ correspond to the bond lengths specified by the force field (FF). Additionally, the bond lengths in any initial configuration must exactly match the FF-specified lengths. See #87 for a more detailed discussion of the problem.

This PR uses the [constrainmol](https://github.com/rsdefever/constrainmol) package to apply the bond length constraints to the initial structures when creating the `System`.

Benefits:
* Guarantees starting structures will have bond lengths matching the FF. 
* Prevents the user from getting (potentially cryptic) errors from Cassandra regarding "broken bonds".

Downsides:
* Requires several minutes to process the starting structures for large systems
* Adds `pyomo` and `ipopt` dependencies (via `constrainmol`)

This PR is still in the early stages. I need to add unit tests.
