### PR TITLE
Change filename of restart from -rst ro _rst

### DIFF
--- a/mosdef_cassandra/examples/nvt.py
+++ b/mosdef_cassandra/examples/nvt.py
@@ -4,7 +4,7 @@ import mosdef_cassandra as mc
 import unyt as u
 
 
-def run_nvt(**custom_args):
+def run_nvt(restart=False, **custom_args):
 
     # Use mBuild to create a methane molecule
     methane = mbuild.load("C", smiles=True)
@@ -39,6 +39,17 @@ def run_nvt(**custom_args):
         temperature=300.0 * u.K,
         **custom_args,
     )
+
+    if restart:
+        # Restart a simulation at 300 K for an additional 10000 MC moves
+        mc.restart(
+            system=system,
+            moveset=moveset,
+            run_type="equilibration",
+            run_length=20000,
+            temperature=300.0 * u.K,
+            **custom_args,
+        )
 
 
 if __name__ == "__main__":

--- a/mosdef_cassandra/runners/runners.py
+++ b/mosdef_cassandra/runners/runners.py
@@ -105,7 +105,7 @@ def restart(system, moveset, run_type, run_length, temperature, **kwargs):
     keyword argument "restart_name" should specify the old "run_name",
     i.e., the "run_name" that you are restarting from. If the "restart_name"
     is not provided or if the "run_name" is the same as "restart_name",
-    "-rst" will be appended to the "run_name".
+    "_rst" will be appended to the "run_name".
 
     Parameters
     ----------

--- a/mosdef_cassandra/tests/test_examples.py
+++ b/mosdef_cassandra/tests/test_examples.py
@@ -9,10 +9,11 @@ from mosdef_cassandra.tests.base_test import BaseTest
 
 
 class TestExamples(BaseTest):
-    def test_run_nvt(self):
+    @pytest.mark.parametrize("restart", [False, True])
+    def test_run_nvt(self, restart):
         with temporary_directory() as tmp_dir:
             with temporary_cd(tmp_dir):
-                ex.run_nvt()
+                ex.run_nvt(restart=restart)
                 log_files = sorted(
                     glob.glob("./mosdef_cassandra*.log"), key=os.path.getmtime
                 )

--- a/mosdef_cassandra/writers/writers.py
+++ b/mosdef_cassandra/writers/writers.py
@@ -88,7 +88,7 @@ def write_input(system, moveset, run_type, run_length, temperature, **kwargs):
         if "restart_name" not in kwargs:
             kwargs["restart_name"] = kwargs["run_name"]
         if kwargs["restart_name"] == kwargs["run_name"]:
-            kwargs["run_name"] = kwargs["run_name"] + "-rst"
+            kwargs["run_name"] = kwargs["run_name"] + "_rst"
 
     inp_data = generate_input(
         system=system,
@@ -142,7 +142,7 @@ def print_inputfile(
         if "restart_name" not in kwargs:
             kwargs["restart_name"] = kwargs["run_name"]
         if kwargs["restart_name"] == kwargs["run_name"]:
-            kwargs["run_name"] = kwargs["run_name"] + "-rst"
+            kwargs["run_name"] = kwargs["run_name"] + "_rst"
 
     inp_data = generate_input(
         system=system,


### PR DESCRIPTION
Addresses #89 by changing the filename of restart simulations from `-rst` to `_rst` to comply with the naming conventions of Cassandra.  Need to add unit tests before review.