### PR TITLE
Fix version dunder in __init__.py and add to bumpversion.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,3 +4,4 @@ commit = True
 tag = True
 
 [bumpversion:file:setup.py]
+[bumpversion:file:mosdef_cassandra/__init__.py]

--- a/mosdef_cassandra/__init__.py
+++ b/mosdef_cassandra/__init__.py
@@ -7,4 +7,4 @@ from .runners.runners import restart
 from .writers.inp_functions import print_valid_kwargs
 from .writers.writers import print_inputfile
 
-__version__ = "0.2.1"
+__version__ = "0.2.3"


### PR DESCRIPTION
I noticed the header on the input files for `0.2.3` still read "written by ... `0.2.1`". This was because we have a version dunder in the main `__init__.py` that was not controlled by `bumpversion`. This PR should address that issue. We should pay close attention on the next release. 