### PR TITLE
Remove references to openbabel in docs

### DIFF
--- a/docs/source/getting_started/examples.rst
+++ b/docs/source/getting_started/examples.rst
@@ -5,13 +5,6 @@ Examples
 Below we provide a few simple examples of short Monte Carlo simulations with
 MoSDeF Cassandra.
 
-.. note::
-  Many of these examples require the openbabel package to create molecules from a
-  SMILES string. Though openbabel is not a required dependency of
-  MoSDeF Casssandra, we strongly recommend that users install it
-  (``conda install -c conda-forge openbabel``) if they
-  would like that functionality.
-
 NVT simulation of methane
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/getting_started/quickstart.rst
+++ b/docs/source/getting_started/quickstart.rst
@@ -32,12 +32,6 @@ with each particle, and the bonds that describe the particle
 connectivity. However, there are no forcefield parameters
 associated with ``methane``.
 
-.. note::
-  Loading a molecule from a SMILES string requires the openbabel package.
-  Though openbabel is not a required dependency, we *strongly* recommend
-  that users install openbabel (``conda install -c conda-forge openbabel``)
-  to have this capability and follow many of our tutorials and examples.
-
 To add forcefield parameters to ``methane``, we first load the OPLS-AA
 forcefield from foyer. The OPLS-AA forcefield is distributed with foyer.
 Be aware that not all atomtypes are currently defined.


### PR DESCRIPTION
Originally, the generate from SMILES capability in `mbuild` required a soft dependency (`openbabel`). Now, the SMILES generation uses `rdkit` and it is a hard dependency. This PR removes the comments suggesting installing `openbabel` from the docs.