### PR TITLE
Added the execution directory as parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 
 #####################################
-VERSION = "0.3.2"
-ISRELEASED = False
-if ISRELEASED:
-    __version__ = VERSION
-else:
-    __version__ = VERSION + ".dev0"
+__version__ = "0.3.2.dev1"
+#ISRELEASED = False
+#if ISRELEASED:
+#   __version__ = VERSION
+#else:
+#    __version__ = VERSION + ".dev0"
 #####################################
 
 requirements = [


### PR DESCRIPTION
Currently, MoSDeF Cassandra runs simulations in the current working directory. This prevents simulations from being launched in parallel on the same machine.

The desired execution directory can be simply be specified to `subprocess.Popen` in order to avoid this limitation. I have implemented this in this PR. The `run_dir` argument is passed to all relevant functions that read or write files.

I have been using it for a little while now, so there should not be any issue with this change.